### PR TITLE
Fix #1, update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,8 @@ $ python manage.py migrate
 
 This package provides permission classes to allow external clients to use your API.
 
-The `HasAPIKey` permission class requires **all clients** to provide a valid API key, regardless of whether they provide authentication details.
-
-If you want to allow clients to provide either an API key or authentication credentials, use the utility `HasAPIKeyOrIsAuthenticated` permission class instead.
+- `HasAPIKey`: this permission class requires **all clients** to provide a valid API key, regardless of whether they provide authentication details.
+- `HasAPIKeyOrIsAuthenticated`: if you want to allow clients to provide either an API key or authentication credentials, use this permission class instead.
 
 As with every permission class, you can either use them globally:
 
@@ -68,7 +67,7 @@ As with every permission class, you can either use them globally:
 
 REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework_api_key.HasAPIKey',
+        'rest_framework_api_key.permissions.HasAPIKey',
     ]
 }
 ```

--- a/rest_framework_api_key/__init__.py
+++ b/rest_framework_api_key/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 default_app_config = 'rest_framework_api_key.apps.RestFrameworkApiKeyConfig'


### PR DESCRIPTION
# Description

- Fix the example usage of `HasAPIKey` as a global permission class
- Provide clearer description of the two available permission classes

Fixes #1 