### PR TITLE
Improve compatibility with Python 3.4

### DIFF
--- a/makemigrations.py
+++ b/makemigrations.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.core.management import call_command
 
 
-def makemigrations(app_name: str):
+def makemigrations(app_name):
     """Make migrations for the given app."""
     DJANGO_SETTINGS = {
         'INSTALLED_APPS': (app_name,)

--- a/rest_framework_api_key/admin.py
+++ b/rest_framework_api_key/admin.py
@@ -31,7 +31,7 @@ class APIKeyAdmin(admin.ModelAdmin):
             return self.readonly_fields + ('client_id', 'revoked',)
         return self.readonly_fields
 
-    def key_message(self, obj: APIKey) -> str:
+    def key_message(self, obj):
         """Message displayed instead of the API key."""
         if obj.key:
             return _SECRET

--- a/rest_framework_api_key/models.py
+++ b/rest_framework_api_key/models.py
@@ -27,11 +27,11 @@ class APIKey(models.Model):
     def __init__(self, *args, **kwargs):
         """Store the initial value of `revoked` to detect changes."""
         super().__init__(*args, **kwargs)
-        self.initial_revoked = self.revoked
+        self._initial_revoked = self.revoked
 
     def _validated_not_unrevoked(self):
         """Validate the key has not been unrevoked."""
-        if self.initial_revoked and not self.revoked:
+        if self._initial_revoked and not self.revoked:
             raise ValidationError(
                 'The API key has been revoked, which cannot be undone.')
 

--- a/runtests.py
+++ b/runtests.py
@@ -39,7 +39,7 @@ SETTINGS_DICT = {
 }
 
 
-def run_tests(directory: str, verbosity: int = 1):
+def run_tests(directory, verbosity=1):
     """Run tests located in the given directory."""
     # Configure Django settings
     from django.conf import settings

--- a/tests/factory.py
+++ b/tests/factory.py
@@ -9,7 +9,7 @@ class APIKeyFactory:
     def __init__(self):
         self.index = 0
 
-    def __call__(self, **kwargs: dict):
+    def __call__(self, **kwargs):
         """Create an APIKey object."""
         kwargs.setdefault('client_id', 'test_{}'.format(self.index))
         self.index += 1

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -1,7 +1,6 @@
 """Test mixins."""
 
 from django.contrib.auth import get_user_model
-from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from rest_framework_api_key.settings import API_KEY_HEADER
@@ -15,7 +14,7 @@ class APIKeyTestMixin:
     def setUp(self):
         self.factory = APIRequestFactory()
 
-    def request(self, *, key: str = None, user: User = None) -> Request:
+    def request(self, *, key=None, user=None):
         """Create a test request."""
         kwargs = {}
         if key is not None:


### PR DESCRIPTION
# Description

Type annotations (3.5+ style) were being used in some tests and `admin.py`. Not sure how tests passed, but they are not supposed to be compatible with Python 3.4, and so were removed.

Other minor fixes.
