### PR TITLE
Automate versioning with bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,6 @@
+[bumpversion]
+current_version = 0.2.2
+commit = True
+tag = True
+
+[bumpversion:file:rest_framework_api_key/__init__.py]

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ djangorestframework = ">=3.8"
 
 [dev-packages]
 django = ">=2.1.2"
+bumpversion = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b450fe7576821b17725783a8886537cb2c959ca9be34f2512434d8f4f4ddfe63"
+            "sha256": "9d8c7fa6d57180a19d02271e1a14cd498809e0942ad10d64c95210b24bd29a66"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,6 +26,14 @@
         }
     },
     "develop": {
+        "bumpversion": {
+            "hashes": [
+                "sha256:6744c873dd7aafc24453d8b6a1a0d6d109faf63cd0cd19cb78fd46e74932c77e",
+                "sha256:6753d9ff3552013e2130f7bc03c1007e24473b4835952679653fb132367bdd57"
+            ],
+            "index": "pypi",
+            "version": "==0.5.3"
+        },
         "django": {
             "hashes": [
                 "sha256:acdcc1f61fdb0a0c82a1d3bf1879a414e7732ea894a7632af7f6d66ec7ab5bb3",

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ $ git push --tags
 
 All contributions are welcome! :wave:
 
-Here's a few ways in which you can help:
+Here are a few ways in which you can help:
 
 - Discovered a bug? Please open a [bug report](https://github.com/florimondmanca/djangorestframework-api-key/issues/new?template=bug_report.md).
 - Have a feature you'd like to see implemented? Please open a [Feature Request](https://github.com/florimondmanca/djangorestframework-api-key/issues/new?template=feature_request.md).

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ This package includes migrations. To update them in case of changes without sett
 $ python makemigrations.py
 ```
 
-### CI/CD - Releases
+### CI/CD
 
 Travis CI is in use to automatically:
 
@@ -174,11 +174,21 @@ Travis CI is in use to automatically:
 
 See `.travis.yml` for further details.
 
-<!-- URLs -->
+### Releasing
 
-[travis-url]: https://travis-ci.org/florimondmanca/djangorestframework-api-key
+When ready to release a new version, use [bumpversion](https://pypi.org/project/bumpversion/) to update the package's version:
 
-[pypi-url]: https://pypi.org/project/djangorestframework-api-key/
+```bash
+$ bumpversion (patch | minor | major)
+```
+
+This will create a new commit and tag that commit with the new version. See [.bumpversion.cfg](.bumpversion.cfg) for more info.
+
+Then, push the tagged commit to remote:
+
+```bash
+$ git push --tags
+```
 
 ## Contributing
 
@@ -189,3 +199,9 @@ Here's a few ways in which you can help:
 - Discovered a bug? Please open a [bug report](https://github.com/florimondmanca/djangorestframework-api-key/issues/new?template=bug_report.md).
 - Have a feature you'd like to see implemented? Please open a [Feature Request](https://github.com/florimondmanca/djangorestframework-api-key/issues/new?template=feature_request.md).
 - For any other contribution, please open a [discussion](https://github.com/florimondmanca/djangorestframework-api-key/issues/new?template=discussion.md).
+
+<!-- URLs -->
+
+[travis-url]: https://travis-ci.org/florimondmanca/djangorestframework-api-key
+
+[pypi-url]: https://pypi.org/project/djangorestframework-api-key/


### PR DESCRIPTION
# Description

[bumpversion](https://pypi.org/project/bumpversion/) is a tool helping with versioning. It is now configured to automatically update the package's version in `__init__.py` and create a tagged commit ready to be pushed (with `git push --tags`) for a new PyPI deployment.

Example with a dry run of a patch bump:

```bash
$ bumpversion --dry-run --verbose patch
Reading config file .bumpversion.cfg:
[bumpversion]
current_version = 0.2.2
commit = True
tag = True

[bumpversion:file:rest_framework_api_key/__init__.py]

Parsing version '0.2.2' using regexp '(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'
Parsed the following values: major=0, minor=2, patch=2
Attempting to increment part 'patch'
Values are now: major=0, minor=2, patch=3
Dry run active, won't touch any files.
Parsing version '0.2.3' using regexp '(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'
Parsed the following values: major=0, minor=2, patch=3
New version will be '0.2.3'
Asserting files rest_framework_api_key/__init__.py contain the version string:
Found '0.2.2' in rest_framework_api_key/__init__.py at line 0: __version__ = '0.2.2'
Would change file rest_framework_api_key/__init__.py:
--- a/rest_framework_api_key/__init__.py
+++ b/rest_framework_api_key/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.2.2'
+__version__ = '0.2.3'
 default_app_config = 'rest_framework_api_key.apps.RestFrameworkApiKeyConfig'
Would write to config file .bumpversion.cfg:
[bumpversion]
current_version = 0.2.3
commit = True
tag = True

[bumpversion:file:rest_framework_api_key/__init__.py]

Would prepare Git commit
Would add changes in file 'rest_framework_api_key/__init__.py' to Git
Would add changes in file '.bumpversion.cfg' to Git
Would commit to Git with message 'Bump version: 0.2.2 → 0.2.3'
Would tag 'v0.2.3' in Git
```