### PR TITLE
Add settings namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,12 @@ $ curl -H 'Api-Token: YOUR_API_TOKEN_HERE' -H 'Api-Secret-Key: YOUR_API_SECRET_K
 
 > Note: values of header settings should be set according to the behavior of [HttpRequest.META](https://docs.djangoproject.com/en/dev/ref/request-response/#django.http.HttpRequest.META). For example, `HTTP_API_KEY` maps to the `Api-Key` header.
 
-`API_KEY_TOKEN_HEADER`:
+`DRF_API_KEY_TOKEN_HEADER`:
 
 - Name of the header which clients use to pass their API token.
 - Default value: `HTTP_API_TOKEN`.
 
-`API_KEY_SECRET_KEY_HEADER`:
+`DRF_API_KEY_SECRET_KEY_HEADER`:
 
 - Name of the header which clients use the pass their API secret key.
 - Default value: `HTTP_API_SECRET_KEY`.

--- a/README.md
+++ b/README.md
@@ -101,12 +101,12 @@ $ curl -H 'Api-Token: YOUR_API_TOKEN_HERE' -H 'Api-Secret-Key: YOUR_API_SECRET_K
 
 > Note: values of header settings should be set according to the behavior of [HttpRequest.META](https://docs.djangoproject.com/en/dev/ref/request-response/#django.http.HttpRequest.META). For example, `HTTP_API_KEY` maps to the `Api-Key` header.
 
-`API_TOKEN_HEADER`:
+`API_KEY_TOKEN_HEADER`:
 
 - Name of the header which clients use to pass their API token.
 - Default value: `HTTP_API_TOKEN`.
 
-`API_SECRET_KEY_HEADER`:
+`API_KEY_SECRET_KEY_HEADER`:
 
 - Name of the header which clients use the pass their API secret key.
 - Default value: `HTTP_API_SECRET_KEY`.

--- a/example_project/example/settings.py
+++ b/example_project/example/settings.py
@@ -54,6 +54,11 @@ TEMPLATES = [
 WSGI_APPLICATION = 'example.wsgi.application'
 
 
+# API Key configuration
+
+API_KEY_TOKEN_HEADER = 'HTTP_API_TOKEN'  # the default
+API_KEY_SECRET_KEY_HEADER = 'HTTP_API_SECRET_KEY'  # the default
+
 # Database
 
 DATABASES = {

--- a/example_project/example/settings.py
+++ b/example_project/example/settings.py
@@ -56,8 +56,8 @@ WSGI_APPLICATION = 'example.wsgi.application'
 
 # API Key configuration
 
-API_KEY_TOKEN_HEADER = 'HTTP_API_TOKEN'  # the default
-API_KEY_SECRET_KEY_HEADER = 'HTTP_API_SECRET_KEY'  # the default
+DRF_API_KEY_TOKEN_HEADER = 'HTTP_API_TOKEN'  # the default
+DRF_API_KEY_SECRET_KEY_HEADER = 'HTTP_API_SECRET_KEY'  # the default
 
 # Database
 

--- a/rest_framework_api_key/apps.py
+++ b/rest_framework_api_key/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class RestFrameworkApiKeyConfig(AppConfig):
     name = 'rest_framework_api_key'
     verbose_name = 'API Key Permissions'
+
+    def ready(self):
+        from . import checks

--- a/rest_framework_api_key/checks.py
+++ b/rest_framework_api_key/checks.py
@@ -1,0 +1,40 @@
+"""API key system checks."""
+
+from django.conf import settings
+from django.core.checks import Error, register
+
+
+def _get_deprecated_setting_error(source, target, id):
+    return Error(
+        'Setting {} has been deprecated in v0.3'.format(source),
+        hint='Use the {} setting instead.'.format(target),
+        obj=settings,
+        id='rest_framework_api_key.{}'.format(id),
+    )
+
+
+@register()
+def check_header_settings_for_deprecation(app_configs, **kwargs):
+    """Check header settings.
+
+    API Key header settings have been updated to use the DRF_API_KEY_*
+    namespace in version 0.3.
+    """
+    errors = []
+    if hasattr(settings, 'API_TOKEN_HEADER'):
+        errors.append(
+            _get_deprecated_setting_error(
+                source='API_TOKEN_HEADER',
+                target='API_KEY_TOKEN_HEADER',
+                id='E001',
+            )
+        )
+    if hasattr(settings, 'API_SECRET_KEY_HEADER'):
+        errors.append(
+            _get_deprecated_setting_error(
+                source='API_SECRET_KEY_HEADER',
+                target='API_KEY_SECRET_KEY_HEADER',
+                id='E002',
+            )
+        )
+    return errors

--- a/rest_framework_api_key/checks.py
+++ b/rest_framework_api_key/checks.py
@@ -25,7 +25,7 @@ def check_header_settings_for_deprecation(app_configs, **kwargs):
         errors.append(
             _get_deprecated_setting_error(
                 source='API_TOKEN_HEADER',
-                target='API_KEY_TOKEN_HEADER',
+                target='DRF_API_KEY_TOKEN_HEADER',
                 id='E001',
             )
         )
@@ -33,7 +33,7 @@ def check_header_settings_for_deprecation(app_configs, **kwargs):
         errors.append(
             _get_deprecated_setting_error(
                 source='API_SECRET_KEY_HEADER',
-                target='API_KEY_SECRET_KEY_HEADER',
+                target='DRF_API_KEY_SECRET_KEY_HEADER',
                 id='E002',
             )
         )

--- a/rest_framework_api_key/permissions.py
+++ b/rest_framework_api_key/permissions.py
@@ -3,7 +3,7 @@
 from rest_framework import permissions
 
 from .models import APIKey
-from .settings import API_KEY_TOKEN_HEADER, API_KEY_SECRET_KEY_HEADER
+from .settings import TOKEN_HEADER, SECRET_KEY_HEADER
 from .crypto import hash_token
 
 
@@ -21,8 +21,8 @@ class HasAPIKey(permissions.BasePermission):
 
     def has_permission(self, request, view):
         """Check whether the API key grants access to a view."""
-        token = request.META.get(API_KEY_TOKEN_HEADER, '')
-        secret_key = request.META.get(API_KEY_SECRET_KEY_HEADER, '')
+        token = request.META.get(TOKEN_HEADER, '')
+        secret_key = request.META.get(SECRET_KEY_HEADER, '')
 
         # Token and secret key must have been given
         if not token or not secret_key:

--- a/rest_framework_api_key/permissions.py
+++ b/rest_framework_api_key/permissions.py
@@ -3,7 +3,7 @@
 from rest_framework import permissions
 
 from .models import APIKey
-from .settings import API_TOKEN_HEADER, API_SECRET_KEY_HEADER
+from .settings import API_KEY_TOKEN_HEADER, API_KEY_SECRET_KEY_HEADER
 from .crypto import hash_token
 
 
@@ -21,8 +21,8 @@ class HasAPIKey(permissions.BasePermission):
 
     def has_permission(self, request, view):
         """Check whether the API key grants access to a view."""
-        token = request.META.get(API_TOKEN_HEADER, '')
-        secret_key = request.META.get(API_SECRET_KEY_HEADER, '')
+        token = request.META.get(API_KEY_TOKEN_HEADER, '')
+        secret_key = request.META.get(API_KEY_SECRET_KEY_HEADER, '')
 
         # Token and secret key must have been given
         if not token or not secret_key:

--- a/rest_framework_api_key/settings.py
+++ b/rest_framework_api_key/settings.py
@@ -16,5 +16,3 @@ SECRET_KEY_HEADER = _get_setting('SECRET_KEY_HEADER', 'HTTP_API_SECRET_KEY')
 # The hashing algorithm used to generate the secret key.
 # 'default' means the default configured password hash algorithm is used.
 SECRET_KEY_ALGORITHM = _get_setting('SECRET_KEY_ALGORITHM', 'default')
-
-print(TOKEN_HEADER, SECRET_KEY_HEADER, SECRET_KEY_ALGORITHM)

--- a/rest_framework_api_key/settings.py
+++ b/rest_framework_api_key/settings.py
@@ -2,11 +2,19 @@
 
 from django.conf import settings
 
-TOKEN_HEADER = getattr(
-    settings, 'DRF_API_KEY_TOKEN_HEADER', 'HTTP_API_TOKEN')
-SECRET_KEY_HEADER = getattr(
-    settings, 'DRF_API_KEY_SECRET_KEY_HEADER', 'HTTP_API_SECRET_KEY')
+_NAMESPACE = 'DRF_API_KEY_'
+
+
+def _get_setting(name, default=None):
+    full_name = _NAMESPACE + name
+    return getattr(settings, full_name, default)
+
+
+TOKEN_HEADER = _get_setting('TOKEN_HEADER', 'HTTP_API_TOKEN')
+SECRET_KEY_HEADER = _get_setting('SECRET_KEY_HEADER', 'HTTP_API_SECRET_KEY')
 
 # The hashing algorithm used to generate the secret key.
 # 'default' means the default configured password hash algorithm is used.
-SECRET_KEY_ALGORITHM = getattr(settings, 'SECRET_KEY_ALGORITHM', 'default')
+SECRET_KEY_ALGORITHM = _get_setting('SECRET_KEY_ALGORITHM', 'default')
+
+print(TOKEN_HEADER, SECRET_KEY_HEADER, SECRET_KEY_ALGORITHM)

--- a/rest_framework_api_key/settings.py
+++ b/rest_framework_api_key/settings.py
@@ -2,9 +2,10 @@
 
 from django.conf import settings
 
-API_TOKEN_HEADER = getattr(settings, 'API_TOKEN_HEADER', 'HTTP_API_TOKEN')
-API_SECRET_KEY_HEADER = getattr(settings, 'API_SECRET_KEY_HEADER',
-                                'HTTP_API_SECRET_KEY')
+API_KEY_TOKEN_HEADER = getattr(settings, 'API_KEY_TOKEN_HEADER',
+                               'HTTP_API_TOKEN')
+API_KEY_SECRET_KEY_HEADER = getattr(settings, 'API_KEY_SECRET_KEY_HEADER',
+                                    'HTTP_API_SECRET_KEY')
 
 # The hashing algorithm used to generate the secret key.
 # 'default' means the default configured password hash algorithm is used.

--- a/rest_framework_api_key/settings.py
+++ b/rest_framework_api_key/settings.py
@@ -2,10 +2,10 @@
 
 from django.conf import settings
 
-API_KEY_TOKEN_HEADER = getattr(settings, 'API_KEY_TOKEN_HEADER',
-                               'HTTP_API_TOKEN')
-API_KEY_SECRET_KEY_HEADER = getattr(settings, 'API_KEY_SECRET_KEY_HEADER',
-                                    'HTTP_API_SECRET_KEY')
+TOKEN_HEADER = getattr(
+    settings, 'DRF_API_KEY_TOKEN_HEADER', 'HTTP_API_TOKEN')
+SECRET_KEY_HEADER = getattr(
+    settings, 'DRF_API_KEY_SECRET_KEY_HEADER', 'HTTP_API_SECRET_KEY')
 
 # The hashing algorithm used to generate the secret key.
 # 'default' means the default configured password hash algorithm is used.

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -3,8 +3,7 @@
 from django.contrib.auth import get_user_model
 from rest_framework.test import APIRequestFactory, force_authenticate
 
-from rest_framework_api_key.settings import (API_KEY_SECRET_KEY_HEADER,
-                                             API_KEY_TOKEN_HEADER)
+from rest_framework_api_key.settings import(SECRET_KEY_HEADER, TOKEN_HEADER
 
 User = get_user_model()
 
@@ -19,9 +18,9 @@ class APIKeyTestMixin:
         """Create a test request."""
         kwargs = {}
         if token is not None:
-            kwargs[API_KEY_TOKEN_HEADER] = token
+            kwargs[TOKEN_HEADER] = token
         if secret_key is not None:
-            kwargs[API_KEY_SECRET_KEY_HEADER] = secret_key
+            kwargs[SECRET_KEY_HEADER] = secret_key
         request = self.factory.get('/test/', **kwargs)
         if user:
             force_authenticate(request, user=user)

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -3,8 +3,8 @@
 from django.contrib.auth import get_user_model
 from rest_framework.test import APIRequestFactory, force_authenticate
 
-from rest_framework_api_key.settings import (API_SECRET_KEY_HEADER,
-                                             API_TOKEN_HEADER)
+from rest_framework_api_key.settings import (API_KEY_SECRET_KEY_HEADER,
+                                             API_KEY_TOKEN_HEADER)
 
 User = get_user_model()
 
@@ -19,9 +19,9 @@ class APIKeyTestMixin:
         """Create a test request."""
         kwargs = {}
         if token is not None:
-            kwargs[API_TOKEN_HEADER] = token
+            kwargs[API_KEY_TOKEN_HEADER] = token
         if secret_key is not None:
-            kwargs[API_SECRET_KEY_HEADER] = secret_key
+            kwargs[API_KEY_SECRET_KEY_HEADER] = secret_key
         request = self.factory.get('/test/', **kwargs)
         if user:
             force_authenticate(request, user=user)

--- a/tests/mixins.py
+++ b/tests/mixins.py
@@ -3,7 +3,7 @@
 from django.contrib.auth import get_user_model
 from rest_framework.test import APIRequestFactory, force_authenticate
 
-from rest_framework_api_key.settings import(SECRET_KEY_HEADER, TOKEN_HEADER
+from rest_framework_api_key.settings import SECRET_KEY_HEADER, TOKEN_HEADER
 
 User = get_user_model()
 


### PR DESCRIPTION
# Description

- Use a namespace for djangorestframework-api-key specific settings: `DRF_API_KEY_*`
- Update header settings to use this namespace
- Add system checks so users are told to update their settings (below is an example output on the updated example project)

```
$ python manage.py check
SystemCheckError: System check identified some issues:

ERRORS:
<Settings "example.settings">: (rest_framework_api_key.E001) Setting API_TOKEN_HEADER has been deprecated in v0.3
        HINT: Use the DRF_API_KEY_TOKEN_HEADER setting instead.
<Settings "example.settings">: (rest_framework_api_key.E002) Setting API_SECRET_KEY_HEADER has been deprecated in v0.3
        HINT: Use the DRF_API_KEY_SECRET_KEY_HEADER setting instead.

System check identified 2 issues (0 silenced).
```

To be released as v0.3.

Fix #13 