### PR TITLE
Fix hashers that emit periods (Fix #22)

### DIFF
--- a/rest_framework_api_key/models.py
+++ b/rest_framework_api_key/models.py
@@ -20,10 +20,7 @@ class APIKeyManager(models.Manager):
         return obj, generated_key
 
     def is_valid(self, key: str) -> bool:
-        try:
-            prefix, _, _ = key.partition(".")
-        except ValueError:
-            return False
+        prefix, _, _ = key.partition(".")
 
         try:
             obj = self.get(id__startswith=prefix, revoked=False)

--- a/rest_framework_api_key/models.py
+++ b/rest_framework_api_key/models.py
@@ -3,7 +3,7 @@ from typing import Tuple
 from django.core.exceptions import ValidationError
 from django.db import models
 
-from ._helpers import generate_key, check_key
+from ._helpers import check_key, generate_key
 
 
 class APIKeyManager(models.Manager):
@@ -21,7 +21,7 @@ class APIKeyManager(models.Manager):
 
     def is_valid(self, key: str) -> bool:
         try:
-            prefix, _ = key.split(".")
+            prefix, _, _ = key.partition(".")
         except ValueError:
             return False
 
@@ -56,14 +56,14 @@ class APIKey(models.Model):
         self._initial_revoked = self.revoked
 
     def prefix(self) -> str:
-        return self.pk.split(".")[0]
+        return self.pk.partition(".")[0]
 
     # Ensure compatibility with Django admin.
     prefix.short_description = "Prefix"
     prefix = property(prefix)
 
     def is_valid(self, key: str) -> bool:
-        _, hashed_key = self.pk.split(".")
+        _, _, hashed_key = self.pk.partition(".")
         return check_key(key, hashed_key)
 
     def clean(self):

--- a/tests/test_api_key_model.py
+++ b/tests/test_api_key_model.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.django_db
 
 def test_key_generation():
     api_key, generated_key = APIKey.objects.create_key(name="test")
-    prefix, hashed_key = api_key.id.split(".")
+    prefix, _, hashed_key = api_key.id.partition(".")
 
     assert prefix and hashed_key
 

--- a/tests/test_has_api_key.py
+++ b/tests/test_has_api_key.py
@@ -25,7 +25,7 @@ def test_if_no_api_key_then_permission_denied(create_request, view):
 
 
 def _scramble_prefix(key: str) -> str:
-    prefix, secret_key = key.split(".")
+    prefix, _, secret_key = key.partition(".")
     truncated_prefix = prefix[:-1]
     return truncated_prefix + "." + secret_key
 


### PR DESCRIPTION
Hashers like bcrypt(256) have periods.

Use .partition instead of .split in this case.
https://docs.python.org/3/library/stdtypes.html#str.partition