### PR TITLE
Fix Pylint issues

### DIFF
--- a/rest_framework_api_key/admin.py
+++ b/rest_framework_api_key/admin.py
@@ -13,7 +13,6 @@ class APIKeyAdmin(admin.ModelAdmin):
         "prefix",
         "created",
         "expiry_date",
-        "has_expired_func",
         "revoked",
     )
     list_filter = ("created",)


### PR DESCRIPTION
```
ERRORS:
<class 'rest_framework_api_key.admin.APIKeyAdmin'>: (admin.E108) The value of 'list_display[4]' refers to 'has_expired_func', which is not a callable, an attribute of 'APIKeyAdmin', or an attribute or method on 'rest_framework_api_key.APIKey'.
```