### PR TITLE
Typed tests

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -4,7 +4,7 @@ export PREFIX=""
 if [ -d 'venv' ] ; then
     export PREFIX="venv/bin/"
 fi
-export SOURCE_FILES="src/rest_framework_api_key"
+export SOURCE_FILES="src/rest_framework_api_key tests"
 
 set -x
 

--- a/scripts/lint
+++ b/scripts/lint
@@ -4,11 +4,11 @@ export PREFIX=""
 if [ -d 'venv' ] ; then
     export PREFIX="venv/bin/"
 fi
-export SOURCE_FILES="src/rest_framework_api_key"
+export SOURCE_FILES="src/rest_framework_api_key tests"
 
 set -x
 
 ${PREFIX}autoflake --in-place --recursive $SOURCE_FILES
-${PREFIX}seed-isort-config --application-directories=$SOURCE_FILES
+${PREFIX}seed-isort-config --application-directories="$SOURCE_FILES"
 ${PREFIX}isort --project=rest_framework_api_key --recursive --apply $SOURCE_FILES
 ${PREFIX}black --target-version=py36 $SOURCE_FILES

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ max-line-length = 88
 
 [mypy]
 disallow_untyped_defs = True
-ignore_missing_imports = False
+ignore_missing_imports = True
 plugins = mypy_django_plugin.main, mypy_drf_plugin.main
 
 [mypy.plugins.django-stubs]

--- a/src/rest_framework_api_key/__init__.py
+++ b/src/rest_framework_api_key/__init__.py
@@ -1,5 +1,15 @@
+import sys
+
 from .__version__ import __version__
+from .types import patch_django_models_generics
 
 default_app_config = "rest_framework_api_key.apps.RestFrameworkApiKeyConfig"
 
 __all__ = ["__version__", "default_app_config"]
+
+if sys.version_info >= (3, 7):
+    patch_django_models_generics()
+
+# Cleanup.
+del sys
+del patch_django_models_generics

--- a/src/rest_framework_api_key/admin.py
+++ b/src/rest_framework_api_key/admin.py
@@ -33,11 +33,7 @@ class APIKeyModelAdmin(admin.ModelAdmin):
         return fields
 
     def save_model(
-        self,
-        request: HttpRequest,
-        obj: APIKey,
-        form: typing.Any = None,
-        change: bool = False,
+        self, request: HttpRequest, obj: APIKey, form: typing.Any, change: bool = False,
     ) -> None:
         created = not obj.pk
 

--- a/src/rest_framework_api_key/permissions.py
+++ b/src/rest_framework_api_key/permissions.py
@@ -34,7 +34,7 @@ class KeyParser:
 
 
 class BaseHasAPIKey(permissions.BasePermission):
-    model: typing.Optional[typing.Type[APIKey]] = None
+    model: typing.Optional[typing.Type[AbstractAPIKey]] = None
     key_parser = KeyParser()
 
     def get_key(self, request: HttpRequest) -> typing.Optional[str]:

--- a/src/rest_framework_api_key/types.py
+++ b/src/rest_framework_api_key/types.py
@@ -1,0 +1,23 @@
+def patch_django_models_generics() -> None:
+    """
+    Add a no-op '.__class_getitem__()' runtime implementation to QuerySet and Manager
+    so that users can use 'QuerySet[MyModel]' and 'Manager[MyModel]' with django-stubs.
+
+    Inspired by:
+    https://github.com/typeddjango/django-stubs/blob/31e795016f154309e675c85616f4f8af033c0860/mypy_django_plugin/django/context.py#L48
+    """
+
+    def noop_class_getitem(cls: type, key: str) -> type:
+        return cls
+
+    from django.db import models
+
+    if not hasattr(models.QuerySet, "__class_getitem__"):
+        models.QuerySet.__class_getitem__ = classmethod(  # type: ignore
+            noop_class_getitem
+        )
+
+    if not hasattr(models.Manager, "__class_getitem__"):
+        models.Manager.__class_getitem__ = classmethod(  # type: ignore
+            noop_class_getitem
+        )

--- a/test_project/heroes/models.py
+++ b/test_project/heroes/models.py
@@ -10,12 +10,12 @@ class Hero(models.Model):
     class Meta:
         verbose_name_plural = "heroes"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 
-class HeroAPIKeyManager(BaseAPIKeyManager):
-    def get_usable_keys(self):
+class HeroAPIKeyManager(BaseAPIKeyManager["HeroAPIKey"]):
+    def get_usable_keys(self) -> models.QuerySet["HeroAPIKey"]:
         return super().get_usable_keys().filter(hero__retired=False)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 import typing
 
 import pytest
+from django.conf import settings
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.http import HttpRequest
-from django.conf import settings
 from django.test import override_settings
 
 from .compat import nullcontext

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,18 +2,20 @@ import typing
 
 import pytest
 from django.conf import settings
-from django.contrib.auth.base_user import AbstractBaseUser
 from django.http import HttpRequest
 from django.test import override_settings
 
 from .compat import nullcontext
 
+if typing.TYPE_CHECKING:
+    from django.contrib.auth.base_user import AbstractBaseUser
+
 
 def pytest_configure() -> None:
     settings.configure(
-        **dict(
-            SECRET_KEY="abcd",
-            INSTALLED_APPS=[
+        **{
+            "SECRET_KEY": "abcd",
+            "INSTALLED_APPS": [
                 # Mandatory
                 "django.contrib.contenttypes",
                 # Permissions
@@ -27,7 +29,7 @@ def pytest_configure() -> None:
                 "rest_framework_api_key",
                 "test_project.heroes",
             ],
-            TEMPLATES=[
+            "TEMPLATES": [
                 # Admin
                 {
                     "BACKEND": "django.template.backends.django.DjangoTemplates",
@@ -39,17 +41,17 @@ def pytest_configure() -> None:
                     },
                 }
             ],
-            MIDDLEWARE=[
+            "MIDDLEWARE": [
                 # Admin
                 "django.contrib.messages.middleware.MessageMiddleware",
                 "django.contrib.sessions.middleware.SessionMiddleware",
                 "django.contrib.auth.middleware.AuthenticationMiddleware",
             ],
-            ROOT_URLCONF="test_project.project.urls",
-            DATABASES={
+            "ROOT_URLCONF": "test_project.project.urls",
+            "DATABASES": {
                 "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}
             },
-        )
+        }
     )
 
 
@@ -69,7 +71,7 @@ def view_with_permissions() -> typing.Callable:
     return create_view
 
 
-def _create_user() -> AbstractBaseUser:
+def _create_user() -> "AbstractBaseUser":
     from django.contrib.auth import get_user_model
 
     User = get_user_model()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import typing
 
 import pytest
+from django.contrib.auth.base_user import AbstractBaseUser
 from django.http import HttpRequest
 from django.conf import settings
 from django.test import override_settings
@@ -8,7 +9,7 @@ from django.test import override_settings
 from .compat import nullcontext
 
 
-def pytest_configure():
+def pytest_configure() -> None:
     settings.configure(
         **dict(
             SECRET_KEY="abcd",
@@ -53,14 +54,14 @@ def pytest_configure():
 
 
 @pytest.fixture
-def view_with_permissions():
+def view_with_permissions() -> typing.Callable:
     from rest_framework.decorators import api_view, permission_classes
     from rest_framework.response import Response
 
-    def create_view(*classes):
+    def create_view(*classes: type) -> typing.Callable:
         @api_view()
         @permission_classes(classes)
-        def view(*args):
+        def view(*args: typing.Any) -> Response:
             return Response()
 
         return view
@@ -68,7 +69,7 @@ def view_with_permissions():
     return create_view
 
 
-def _create_user():
+def _create_user() -> AbstractBaseUser:
     from django.contrib.auth import get_user_model
 
     User = get_user_model()
@@ -86,11 +87,12 @@ def _create_user():
         },
     ],
 )
-def fixture_key_header_config(request) -> dict:
-    config = request.param
+def fixture_key_header_config(request: typing.Any) -> typing.Iterator[dict]:
+    config: dict = request.param
 
+    ctx: typing.ContextManager[None]
     if config.get("set_custom_header_setting"):
-        ctx = override_settings(API_KEY_CUSTOM_HEADER=config["header"])
+        ctx = override_settings(API_KEY_CUSTOM_HEADER=config["header"])  # type: ignore
     else:
         ctx = nullcontext()
 
@@ -99,19 +101,21 @@ def fixture_key_header_config(request) -> dict:
 
 
 @pytest.fixture(name="build_create_request")
-def fixture_build_create_request(key_header_config: dict):
+def fixture_build_create_request(key_header_config: dict) -> typing.Callable:
     from rest_framework.test import APIRequestFactory, force_authenticate
     from rest_framework_api_key.models import AbstractAPIKey
 
-    def build_create_request(model: typing.Type[AbstractAPIKey]):
+    def build_create_request(model: typing.Type[AbstractAPIKey]) -> typing.Callable:
         request_factory = APIRequestFactory()
 
         _MISSING = object()
 
         def create_request(
-            authenticated: bool = False, authorization: str = _MISSING, **kwargs
-        ):
+            authenticated: bool = False, **kwargs: typing.Any,
+        ) -> HttpRequest:
             headers = {}
+
+            authorization = kwargs.pop("authorization", _MISSING)
 
             if authorization is not None:
                 kwargs.setdefault("name", "test")
@@ -139,7 +143,7 @@ def fixture_build_create_request(key_header_config: dict):
 
 
 @pytest.fixture(name="create_request")
-def fixture_create_request(build_create_request) -> HttpRequest:
+def fixture_create_request(build_create_request: typing.Callable) -> typing.Callable:
     from rest_framework_api_key.models import APIKey
 
     return build_create_request(APIKey)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,18 +1,17 @@
 import typing
 
 import pytest
-from django.contrib.admin import site, ModelAdmin
+from django.contrib.admin import ModelAdmin, site
 from django.contrib.messages import get_messages
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpRequest
 from django.test import RequestFactory
+from test_project.heroes.admin import HeroAPIKeyModelAdmin
+from test_project.heroes.models import Hero, HeroAPIKey
 
 from rest_framework_api_key.admin import APIKeyModelAdmin
 from rest_framework_api_key.models import APIKey
-
-from test_project.heroes.admin import HeroAPIKeyModelAdmin
-from test_project.heroes.models import Hero, HeroAPIKey
 
 
 @pytest.fixture(name="req")

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,11 +1,11 @@
+import typing
+
 import pytest
-from django.contrib.admin import ModelAdmin, site
-from django.contrib.auth import login
-from django.contrib.auth.middleware import AuthenticationMiddleware
-from django.contrib.auth.models import User
+from django.contrib.admin import site, ModelAdmin
 from django.contrib.messages import get_messages
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
+from django.http import HttpRequest
 from django.test import RequestFactory
 
 from rest_framework_api_key.admin import APIKeyModelAdmin
@@ -16,7 +16,7 @@ from test_project.heroes.models import Hero, HeroAPIKey
 
 
 @pytest.fixture(name="req")
-def fixture_req(rf: RequestFactory):
+def fixture_req(rf: RequestFactory) -> HttpRequest:
     messages = MessageMiddleware()
     sessions = SessionMiddleware()
     request = rf.post("/")
@@ -37,12 +37,17 @@ def fixture_req(rf: RequestFactory):
         ),
     ],
 )
-def test_create(req, model, model_admin, build_api_key):
+def test_create(
+    req: HttpRequest,
+    model: type,
+    model_admin: typing.Type[ModelAdmin],
+    build_api_key: typing.Callable,
+) -> None:
     admin = model_admin(model, site)
     api_key = build_api_key(model)
 
     assert not api_key.pk
-    admin.save_model(req, obj=api_key)
+    admin.save_model(req, obj=api_key, form=None, change=False)
     assert api_key.pk
 
     messages = get_messages(req)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,5 +1,5 @@
 from django.core.management import call_command
 
 
-def test_system_checks_pass():
+def test_system_checks_pass() -> None:
     call_command("check")

--- a/tests/test_legacy_key_generator.py
+++ b/tests/test_legacy_key_generator.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+import typing
 
 import pytest
 
@@ -11,16 +11,18 @@ pytestmark = pytest.mark.django_db
 class LegacyKeyGenerator(KeyGenerator):
     """Pre-1.4 key generator."""
 
-    def generate(self) -> Tuple[str, str]:  # type: ignore
+    def _legacy_generate(self) -> typing.Tuple[str, str]:
         prefix = self.get_prefix()
         secret_key = self.get_secret_key()
         key = concatenate(prefix, secret_key)
         hashed_key = concatenate(prefix, self.hash(key))
         return key, hashed_key
 
+    generate = _legacy_generate  # type: ignore
+
 
 @pytest.fixture(name="manager")
-def fixture_manager():
+def fixture_manager() -> BaseAPIKeyManager:
     class Manager(BaseAPIKeyManager):
         key_generator = LegacyKeyGenerator()
 
@@ -29,5 +31,5 @@ def fixture_manager():
     return manager
 
 
-def test_manager_with_legacy_key_generator(manager):
+def test_manager_with_legacy_key_generator(manager: BaseAPIKeyManager) -> None:
     manager.create_key(name="test")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,4 +1,6 @@
+import datetime as dt
 import string
+import typing
 
 import pytest
 from django.core.exceptions import ValidationError
@@ -11,7 +13,7 @@ from .dateutils import NOW, TOMORROW, YESTERDAY
 pytestmark = pytest.mark.django_db
 
 
-def test_key_generation():
+def test_key_generation() -> None:
     api_key, generated_key = APIKey.objects.create_key(name="test")
     prefix = api_key.prefix
     hashed_key = api_key.hashed_key
@@ -28,12 +30,12 @@ def test_key_generation():
     assert api_key.is_valid(hashed_key) is False
 
 
-def test_name_is_required():
+def test_name_is_required() -> None:
     with pytest.raises(IntegrityError):
         APIKey.objects.create()
 
 
-def test_cannot_unrevoke():
+def test_cannot_unrevoke() -> None:
     api_key, _ = APIKey.objects.create_key(name="test", revoked=True)
 
     # Try to unrevoke the API key programmatically.
@@ -50,12 +52,14 @@ def test_cannot_unrevoke():
     "expiry_date, has_expired",
     [(None, False), (NOW, True), (TOMORROW, False), (YESTERDAY, True)],
 )
-def test_has_expired(expiry_date, has_expired):
+def test_has_expired(
+    expiry_date: typing.Optional[dt.datetime], has_expired: bool
+) -> None:
     api_key, _ = APIKey.objects.create_key(name="test", expiry_date=expiry_date)
     assert api_key.has_expired is has_expired
 
 
-def test_custom_api_key_model():
+def test_custom_api_key_model() -> None:
     hero = Hero.objects.create()
     hero_api_key, generated_key = HeroAPIKey.objects.create_key(name="test", hero=hero)
     assert hero_api_key.is_valid(generated_key)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,9 +5,10 @@ import typing
 import pytest
 from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
+from test_project.heroes.models import Hero, HeroAPIKey
+
 from rest_framework_api_key.models import APIKey
 
-from test_project.heroes.models import HeroAPIKey, Hero
 from .dateutils import NOW, TOMORROW, YESTERDAY
 
 pytestmark = pytest.mark.django_db

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,10 +1,10 @@
-import typing
 import datetime as dt
+import typing
 
 import pytest
 from django.conf.global_settings import PASSWORD_HASHERS
-from django.views import View
 from django.test import override_settings
+from django.views import View
 from rest_framework import generics, permissions
 from rest_framework.request import Request
 from rest_framework.response import Response

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -108,7 +108,7 @@ def test_object_permission(create_request: typing.Callable) -> None:
         ) -> bool:
             return False
 
-    class View(generics.GenericAPIView):
+    class ExampleView(generics.GenericAPIView):
         # See: https://github.com/typeddjango/djangorestframework-stubs/issues/37
         permission_classes = [HasAPIKey | DenyObject]  # type: ignore
 
@@ -116,7 +116,7 @@ def test_object_permission(create_request: typing.Callable) -> None:
             self.check_object_permissions(request, object())
             return Response()
 
-    view = View.as_view()
+    view = ExampleView.as_view()
 
     request = create_request(authorization=None)
     response = view(request)

--- a/tests/test_permissions_combination.py
+++ b/tests/test_permissions_combination.py
@@ -1,4 +1,8 @@
+import typing
+
 import pytest
+from rest_framework.request import Request
+from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 
 from rest_framework_api_key.permissions import HasAPIKey
@@ -7,19 +11,25 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture(name="view")
-def fixture_view(view_with_permissions):
-    return view_with_permissions(HasAPIKey | IsAuthenticated)
+def fixture_view(view_with_permissions: typing.Callable) -> typing.Callable:
+    # See: https://github.com/typeddjango/djangorestframework-stubs/issues/37
+    permission_class = HasAPIKey | IsAuthenticated  # type: ignore
+    return view_with_permissions(permission_class)
 
 
-def test_if_authenticated_and_no_api_key_then_permission_granted(create_request, view):
+def test_if_authenticated_and_no_api_key_then_permission_granted(
+    create_request: typing.Callable[..., Request],
+    view: typing.Callable[[Request], Response],
+) -> None:
     request = create_request(authenticated=True, authorization=None)
     response = view(request)
     assert response.status_code == 200, response.data
 
 
 def test_if_authenticated_and_revoked_api_key_then_permission_granted(
-    create_request, view
-):
+    create_request: typing.Callable[..., Request],
+    view: typing.Callable[[Request], Response],
+) -> None:
     request = create_request(authenticated=True, revoked=True)
     response = view(request)
     assert response.status_code == 200, response.data

--- a/tests/test_permissions_combination.py
+++ b/tests/test_permissions_combination.py
@@ -1,9 +1,9 @@
 import typing
 
 import pytest
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.permissions import IsAuthenticated
 
 from rest_framework_api_key.permissions import HasAPIKey
 

--- a/tests/test_permissions_custom.py
+++ b/tests/test_permissions_custom.py
@@ -1,8 +1,7 @@
 import typing
 
 import pytest
-
-from test_project.heroes.models import HeroAPIKey, Hero
+from test_project.heroes.models import Hero, HeroAPIKey
 from test_project.heroes.permissions import HasHeroAPIKey
 
 pytestmark = pytest.mark.django_db

--- a/tests/test_permissions_custom.py
+++ b/tests/test_permissions_custom.py
@@ -1,3 +1,5 @@
+import typing
+
 import pytest
 
 from test_project.heroes.models import HeroAPIKey, Hero
@@ -7,29 +9,37 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture(name="view")
-def fixture_view(view_with_permissions):
+def fixture_view(view_with_permissions: typing.Callable) -> typing.Callable:
     return view_with_permissions(HasHeroAPIKey)
 
 
 @pytest.fixture(name="create_hero_request")
-def fixture_create_hero_request(build_create_request):
+def fixture_create_hero_request(
+    build_create_request: typing.Callable,
+) -> typing.Callable:
     return build_create_request(HeroAPIKey)
 
 
-def test_non_hero_api_key_denied(create_request, view):
+def test_non_hero_api_key_denied(
+    create_request: typing.Callable, view: typing.Callable
+) -> None:
     request = create_request()
     response = view(request)
     assert response.status_code == 403
 
 
-def test_hero_api_key_granted(create_hero_request, view):
+def test_hero_api_key_granted(
+    create_hero_request: typing.Callable, view: typing.Callable
+) -> None:
     hero = Hero.objects.create()
     hero_request = create_hero_request(hero=hero)
     response = view(hero_request)
     assert response.status_code == 200
 
 
-def test_retired_hero_denied(create_hero_request, view):
+def test_retired_hero_denied(
+    create_hero_request: typing.Callable, view: typing.Callable
+) -> None:
     hero = Hero.objects.create(retired=True)
     hero_request = create_hero_request(hero=hero)
     response = view(hero_request)


### PR DESCRIPTION
Fixes #89 

This includes a breaking change that would require 3.7+: using `Model` and `QuerySet` generics with `django-stubs`. Will want to look at dropping this usage to stay 3.6-compatible, i.e. by adding `# type: ignore` in the relevant places of the tests and `test_project`. (This means that our users may encounter typing issues, though.)