### PR TITLE
Add and document BaseAPIKeyManager.get_from_key()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add a new method to the `APIKey` object manager, `BaseAPIKeyManager.get_from_key()`, to allow for retrieving `APIKey` objects based on generated keys.
+
 ## [v1.4.1] - 2019-08-24
 
 ### Added

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -142,6 +142,16 @@ API keys can be created, viewed and revoked programmatically by manipulating the
 !!! danger
     To prevent leaking API keys, you must only give the `key` **to the client that triggered its generation**. In particular, **do not keep any trace of it on the server**.
 
+- To retrieve an `APIKey` instance based on its generated key (which is not stored in the database) use the `.get_from_key()` method on the `APIKey` objects manager instead of `.get()`:
+
+```python
+>>> from rest_framework_api_key.models import APIKey
+>>> # Generated keys follow this format
+>>> generated_key = "zx6UGvip.XakvjxQJUSRCHIEdMUDtwZtEnb4YLHaL"
+>>> api_key = APIKey.objects.get_from_key(generated_key)
+>>> # Proceed with the `api_key` object...
+```
+
 ## Customization
 
 This package provides various customization APIs that allow you to extend its basic behavior.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -142,14 +142,23 @@ API keys can be created, viewed and revoked programmatically by manipulating the
 !!! danger
     To prevent leaking API keys, you must only give the `key` **to the client that triggered its generation**. In particular, **do not keep any trace of it on the server**.
 
-- To retrieve an `APIKey` instance based on its generated key (which is not stored in the database) use the `.get_from_key()` method on the `APIKey` objects manager instead of `.get()`:
+- To retrieve an `APIKey` instance based on its generated key (which is not stored in the database) use the `.get_from_key()` method on the `APIKey` objects manager instead of `.get()`. This is useful if you'd like to access an `APIKey` object from a view protected by a `HasAPIKey` permission.
 
 ```python
->>> from rest_framework_api_key.models import APIKey
->>> # Generated keys follow this format
->>> generated_key = "zx6UGvip.XakvjxQJUSRCHIEdMUDtwZtEnb4YLHaL"
->>> api_key = APIKey.objects.get_from_key(generated_key)
->>> # Proceed with the `api_key` object...
+from rest_framework.views import APIView
+from rest_framework_api_key.models import APIKey
+from rest_framework_api_key.permissions import HasAPIKey
+
+from .models import Project
+
+class ProjectListView(APIView):
+    permission_classes = [HasAPIKey]
+
+    def get(self, request):
+        """Retrieve a project based on the request API key."""
+        key = request.META["HTTP_AUTHORIZATION"]
+        api_key = APIKey.objects.get_from_key(key)
+        project = Project.objects.get(api_key=api_key)
 ```
 
 ## Customization

--- a/src/rest_framework_api_key/models.py
+++ b/src/rest_framework_api_key/models.py
@@ -57,7 +57,7 @@ class BaseAPIKeyManager(models.Manager):
     def is_valid(self, key: str) -> bool:
         try:
             api_key = self.get_from_key(key)
-        except (self.model.DoesNotExist, ValidationError):
+        except self.model.DoesNotExist:
             return False
 
         if api_key.has_expired:

--- a/src/rest_framework_api_key/models.py
+++ b/src/rest_framework_api_key/models.py
@@ -43,7 +43,10 @@ class BaseAPIKeyManager(models.Manager):
     def get_from_key(self, key: str) -> "AbstractAPIKey":
         prefix, _, _ = key.partition(".")
         queryset = self.get_usable_keys()
-        api_key = queryset.get(prefix=prefix)
+        try:
+            api_key = queryset.get(prefix=prefix)
+        except self.model.DoesNotExist:
+            raise  # For the sake of being explicit.
         if not api_key.is_valid(key):
             raise ValidationError("Key is not valid.")
         else:

--- a/src/rest_framework_api_key/models.py
+++ b/src/rest_framework_api_key/models.py
@@ -40,17 +40,19 @@ class BaseAPIKeyManager(models.Manager):
     def get_usable_keys(self) -> models.QuerySet:
         return self.filter(revoked=False)
 
-    def is_valid(self, key: str) -> bool:
+    def get_from_key(self, key: str) -> "AbstractAPIKey":
         prefix, _, _ = key.partition(".")
-
         queryset = self.get_usable_keys()
-
-        try:
-            api_key = queryset.get(prefix=prefix)
-        except self.model.DoesNotExist:
-            return False
-
+        api_key = queryset.get(prefix=prefix)
         if not api_key.is_valid(key):
+            raise ValidationError("Key is not valid.")
+        else:
+            return api_key
+
+    def is_valid(self, key: str) -> bool:
+        try:
+            api_key = self.get_from_key(key)
+        except (self.model.DoesNotExist, ValidationError):
             return False
 
         if api_key.has_expired:

--- a/src/rest_framework_api_key/models.py
+++ b/src/rest_framework_api_key/models.py
@@ -43,12 +43,14 @@ class BaseAPIKeyManager(models.Manager):
     def get_from_key(self, key: str) -> "AbstractAPIKey":
         prefix, _, _ = key.partition(".")
         queryset = self.get_usable_keys()
+
         try:
             api_key = queryset.get(prefix=prefix)
         except self.model.DoesNotExist:
             raise  # For the sake of being explicit.
+
         if not api_key.is_valid(key):
-            raise ValidationError("Key is not valid.")
+            raise self.model.DoesNotExist("Key is not valid.")
         else:
             return api_key
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -61,3 +61,25 @@ def test_custom_api_key_model():
     assert hero_api_key.is_valid(generated_key)
     assert hero_api_key.hero.id == hero.id
     assert hero.api_keys.first() == hero_api_key
+
+
+@pytest.mark.django_db
+def test_api_key_manager_get_from_key():
+    api_key, generated_key = APIKey.objects.create_key(name="test")
+    retrieved_key = APIKey.objects.get_from_key(generated_key)
+    assert retrieved_key == api_key
+
+
+@pytest.mark.django_db
+def test_api_key_manager_get_from_key_missing_key():
+    with pytest.raises(APIKey.DoesNotExist):
+        APIKey.objects.get_from_key("foobar")
+
+
+@pytest.mark.django_db
+def test_api_key_manager_get_from_key_invalid_key():
+    api_key, generated_key = APIKey.objects.create_key(name="test")
+    prefix, _, _ = generated_key.partition(".")
+    invalid_key = f"{prefix}.foobar"
+    with pytest.raises(ValidationError):
+        APIKey.objects.get_from_key(invalid_key)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -81,5 +81,5 @@ def test_api_key_manager_get_from_key_invalid_key():
     api_key, generated_key = APIKey.objects.create_key(name="test")
     prefix, _, _ = generated_key.partition(".")
     invalid_key = f"{prefix}.foobar"
-    with pytest.raises(ValidationError):
+    with pytest.raises(APIKey.DoesNotExist):
         APIKey.objects.get_from_key(invalid_key)


### PR DESCRIPTION
## Overview

This PR exposes a new method, `BaseAPIKeyManager.get_from_key()`, for retrieving APIKey objects based on a generated key that is not stored in the database. In addition, it refactors the `BaseAPIKeyManager.is_valid()` method to use the new `.get_from_key()` method.

Fixes #92.

## Testing instructions

* Confirm the three new tests pass
* Run `scripts/serve`, navigate to http://localhost:8000/guide/#programmatic-usage, and confirm the new bulleted section at the end of `Programmatic usage` looks good