### PR TITLE
Easily Retrieve the Raw API Key from a View

### DIFF
--- a/src/rest_framework_api_key/permissions.py
+++ b/src/rest_framework_api_key/permissions.py
@@ -37,8 +37,9 @@ class BaseHasAPIKey(permissions.BasePermission):
     model: typing.Optional[typing.Type[APIKey]] = None
     key_parser = KeyParser()
 
-    def get_key(self, request: HttpRequest) -> typing.Optional[str]:
-        return self.key_parser.get(request)
+    @classmethod
+    def get_key(cls, request: HttpRequest) -> typing.Optional[str]:
+        return cls.key_parser.get(request)
 
     def has_permission(self, request: HttpRequest, view: typing.Any) -> bool:
         assert self.model is not None, (

--- a/tests/compat.py
+++ b/tests/compat.py
@@ -1,10 +1,11 @@
 import sys
+from typing import Generator
 
 if sys.version_info < (3, 7):
     from contextlib import contextmanager
 
     @contextmanager
-    def nullcontext():
+    def nullcontext() -> Generator:
         yield
 
 


### PR DESCRIPTION
*Figured that this would be an easy one to get my feet wet.*

Solves #98 as suggested in the issue.

This turns `get_key` on the `BaseHasAPIKey` permission class into a `@classmethod` which will allow a view or viewset to access the raw API key using `HasAPIKey.get_key(request)`.

This will not break backwards compatibility if someone has done `HasAPIKey().get_key(request)` because Python will automatically convert the instance and pass the appropriate `cls` type.

## Compat Annotation

In order for `scripts/check` to run, I had to add the `-> Generator` to the `nullcontext` context manager. Not sure if this is a standalone issue or what, but it can't hurt others....I hope.

## Testing

**Note: the following text will be removed before merging the PR.**

I am trying to understand the test fixtures, but I cannot figure out how to have the `create_request` fixture set up the request correctly for my view to parse the API key.

The following is what I'm attempting to do. The `HasAPIKey.get_key(request)` though is either returning None or the entire header. What's the correct argument to `create_request` for it to pass my custom key without mangling it?
```
def test_retrieving_raw_api_key_within_view(create_request, key_header_config):
    expected_key = 'thisismyapikey'
    expected_status = 200

    class View(generics.GenericAPIView):
        permission_classes = []

        def get(self, request):
            raw_key = HasAPIKey.get_key(request)
            status_code = expected_status if raw_key == expected_key else expected_status + 1
            return Response(status=status_code)

    view = View.as_view()
    request = create_request(authenticated=True, authorization='Api-Key %s' % expected_key)
    response = view(request)
    assert response.status_code == expected_status
```