### PR TITLE
Fix the install script to allow for windows virtual environments also

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -6,7 +6,17 @@
 export PREFIX=""
 if [ -z $CI ]; then
   $PYTHON -m venv venv
-  export PREFIX="venv/bin/"
+fi
+
+
+if [[ "$OSTYPE" == "cygwin" ]]; then
+	# POSIX compatibility layer and Linux environment emulation for Windows
+	export PREFIX="venv/Scripts/"
+elif [[ "$OSTYPE" == "msys" ]]; then
+	# Lightweight shell and GNU utilities compiled for Windows (part of MinGW)
+	export PREFIX="venv/Scripts/"
+else
+	export PREFIX="venv/bin/"
 fi
 
 set -x


### PR DESCRIPTION
Since I so very much loved the repository and tried learning the way it is setup (am trying to set a libary up at work), I realized that the install script only works for Linux environments since venv folders on Windows produce a slightly different path because of which it failed for me.

So I decided to fix it by tinkering with the shell script. It works on windows now and going by this [SO Answer](https://stackoverflow.com/questions/394230/how-to-detect-the-os-from-a-bash-script), seems like it should work well.