### PR TITLE
Freeze legacy key generator

### DIFF
--- a/tests/test_legacy_key_generator.py
+++ b/tests/test_legacy_key_generator.py
@@ -1,22 +1,34 @@
 from typing import Tuple
 
 import pytest
+from django.contrib.auth.hashers import make_password
+from django.utils.crypto import get_random_string
 
-from rest_framework_api_key.crypto import KeyGenerator, concatenate
+from rest_framework_api_key.crypto import KeyGenerator
 from rest_framework_api_key.models import APIKey, BaseAPIKeyManager
 
 pytestmark = pytest.mark.django_db
 
 
 class LegacyKeyGenerator(KeyGenerator):
-    """Pre-1.4 key generator."""
+    """
+    Pre-1.4 key generator.
+
+    The key generator interface was updated in v1.4 via:
+    https://github.com/florimondmanca/djangorestframework-api-key/pull/62
+
+    We must ensure that custom key generators created based on the pre-1.4 interface
+    continue to work in 1.x.
+    """
 
     def generate(self) -> Tuple[str, str]:  # type: ignore
-        prefix = self.get_prefix()
-        secret_key = self.get_secret_key()
-        key = concatenate(prefix, secret_key)
-        hashed_key = concatenate(prefix, self.hash(key))
-        return key, hashed_key
+        # NOTE: this method should replicate the behavior before #62, and
+        # have no dependencies on the current `rest_framework_api_key` package.
+        prefix = get_random_string(8)
+        secret_key = get_random_string(32)
+        key = prefix + "." + secret_key
+        key_id = prefix + "." + make_password(key)
+        return key, key_id
 
 
 @pytest.fixture(name="manager")


### PR DESCRIPTION
The current fake custom key generator based on the interface before #62 was depending on code from the current package state. This isn't stable, so this PR removes any dependency other than Django.