### PR TITLE
Drop support for `django<2.2`

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -39,9 +39,9 @@ jobs:
   - job: Linux
     strategy:
       matrix:
-        py3.6-dj2.0:
+        py3.6-dj2.2:
           pythonVersion: "3.6"
-          djangoVersion: "2.0.*"
+          djangoVersion: "2.2.*"
         py3.7-dj2.2:
           pythonVersion: "3.7"
           djangoVersion: "2.2.*"

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,6 @@ setup(
         "Environment :: Web Environment",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Framework :: Django",
-        "Framework :: Django :: 2.0",
-        "Framework :: Django :: 2.1",
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.0",
     ],


### PR DESCRIPTION
Per [Supported Versions](https://www.djangoproject.com/download/#supported-versions):

- Django 2.0 is EOL since April 2019.
- Django 2.1 is EOL since Jan 2020.

We should try to keep the maintenance burden as low as possible, so let's drop support for them in 2.0.

Refs #100