### PR TITLE
[2.0.0 Cleanup] Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+graft src
+include README.md
+include CHANGELOG.md
+include LICENSE


### PR DESCRIPTION
This is required for `py.typed` to be included in the package build (sdist/wheel), and type hints to be detected by mypy.

Refs #88, #122, cleanup for #127 