### PR TITLE
For for auth headers not being found when sending request using Django Test Client

### DIFF
--- a/src/rest_framework_api_key/permissions.py
+++ b/src/rest_framework_api_key/permissions.py
@@ -17,7 +17,10 @@ class KeyParser:
         return self.get_from_authorization(request)
 
     def get_from_authorization(self, request: HttpRequest) -> typing.Optional[str]:
-        authorization = request.META.get("HTTP_AUTHORIZATION")
+        authorization = (
+            request.META.get("HTTP_AUTHORIZATION") or
+            request.META.get("headers", {}).get("Authorization")
+        )
 
         if not authorization:
             return None


### PR DESCRIPTION
When sending requests with valid auth headers using the Django test client `request.META.get("HTTP_AUTHORIZATION")` is empty. So the api will return 403. 

This change fixes that.