### PR TITLE
Fix Broken URL

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -173,7 +173,7 @@ This package provides various customization APIs that allow you to extend its ba
 If the built-in `APIKey` model doesn't fit your needs, you can create your own by subclassing `AbstractAPIKey`. This is particularly useful if you need to **store extra information** or **link API keys to other models** using a `ForeignKey` or a `ManyToManyField`.
 
 !!! warning
-    Associating API keys to users, directly or indirectly, can present a security risk. See also: [Should I use API keys?](/#should-i-use-api-keys).
+    Associating API keys to users, directly or indirectly, can present a security risk. See also: [Should I use API keys?](https://florimondmanca.github.io/djangorestframework-api-key/#should-i-use-api-keys).
  
 #### Example
 


### PR DESCRIPTION
URL on [Should I use API Keys?](https://florimondmanca.github.io/djangorestframework-api-key/guide/#api-key-models) within warning box is broken and leads to a 404 not found resource.