### PR TITLE
Add support for custom API keyword

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -87,6 +87,34 @@ where `<API_KEY>` refers to the full generated API key (see [Creating and managi
 
 To know under which conditions access is granted, please see [Grant scheme](security.md#grant-scheme).
 
+#### Custom keyword
+
+ If you want to use a different keyword in the header, such as `Bearer`, simply subclass `BearerKeyParser` set the `keyword` class variable. Next subclass `HasAPIKey` set the `key_parser` class variable to use your new subclass.
+
+This is useful if are writing your API for an application the requires a certain keyword, like `Bearer`. 
+
+For example:
+
+```python
+# settings.py
+from rest_framework_api_key.permissions import BaseHasAPIKey, KeyParser
+
+class BearerKeyParser(KeyParser):
+    keyword = "Bearer"
+
+
+class HasAPIKey(BaseHasAPIKey):
+    key_parser = BearerKeyParser()
+```
+
+then clients must make authorized requests using:
+
+```
+Authorization: Bearer <API_KEY>
+```
+
+where `<API_KEY>` refers to the full generated API key.
+
 #### Custom header
 
 You can set the `API_KEY_CUSTOM_HEADER` setting to a non-`None` value to require clients to pass their API key in a custom header instead of the `Authorization` header.
@@ -109,27 +137,6 @@ X-Api-Key: <API_KEY>
 where `<API_KEY>` refers to the full generated API key.
 
 Please refer to [HttpRequest.META](https://docs.djangoproject.com/en/2.2/ref/request-response/#django.http.HttpRequest.META) for more information on headers in Django.
-
-#### Custom keyword
-
-You can set the `API_KEY_CUSTOM_KEYWORD` setting to a non-`None` value to require clients to pass their API key with a custom keyword instead of the `Api-Key` keyword.
-
-This is useful if are writing your API for an application the requires a certain keyword, like `Bearer`. 
-
-For example, if you set:
-
-```python
-# settings.py
-API_KEY_CUSTOM_KEYWORD = "Bearer"
-```
-
-then clients must make authorized requests using:
-
-```
-Authorization: Bearer <API_KEY>
-```
-
-where `<API_KEY>` refers to the full generated API key.
 
 ### Creating and managing API keys
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -89,7 +89,7 @@ To know under which conditions access is granted, please see [Grant scheme](secu
 
 #### Custom keyword
 
- If you want to use a different keyword in the header, such as `Bearer`, simply subclass `BearerKeyParser` set the `keyword` class variable. Next subclass `HasAPIKey` set the `key_parser` class variable to use your new subclass.
+ If you want to use a different keyword in the header, such as `Bearer`, simply subclass `KeyParser` set the `keyword` class variable. Next subclass `BaseHasAPIKey` set the `key_parser` class variable to use your new subclass.
 
 This is useful if are writing your API for an application the requires a certain keyword, like `Bearer`. 
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -87,33 +87,7 @@ where `<API_KEY>` refers to the full generated API key (see [Creating and managi
 
 To know under which conditions access is granted, please see [Grant scheme](security.md#grant-scheme).
 
-#### Custom keyword
-
- If you want to use a different keyword in the header, such as `Bearer`, simply subclass `KeyParser` set the `keyword` class variable. Next subclass `BaseHasAPIKey` set the `key_parser` class variable to use your new subclass.
-
-This is useful if are writing your API for an application the requires a certain keyword, like `Bearer`. 
-
-For example:
-
-```python
-# settings.py
-from rest_framework_api_key.permissions import BaseHasAPIKey, KeyParser
-
-class BearerKeyParser(KeyParser):
-    keyword = "Bearer"
-
-
-class HasAPIKey(BaseHasAPIKey):
-    key_parser = BearerKeyParser()
-```
-
-then clients must make authorized requests using:
-
-```
-Authorization: Bearer <API_KEY>
-```
-
-where `<API_KEY>` refers to the full generated API key.
+If wanting to also customize the keyword used for parsing the Api-Key, please see [API key Custom Keyword](guide.md#api-key-custom-keyword)
 
 #### Custom header
 
@@ -346,6 +320,43 @@ class HasOrganizationAPIKey(BaseHasAPIKey):
     # ...
     key_parser = CookieKeyParser()
 ```
+
+#### API key Custom Keyword
+Another default is to retrieve the key following the `Api-Key` keyword. 
+
+Example:
+
+
+```
+Authorization: Api-Key <API_KEY>
+```
+
+If you want to use a different keyword in the header, such as `Bearer`, simply subclass `KeyParser` set the `keyword` class variable. Next subclass `BaseHasAPIKey` set the `key_parser` class variable to use your new subclass.
+
+This is useful if are writing your API for an application the requires a certain keyword, like `Bearer`.
+
+Example:
+
+```python
+# settings.py
+from rest_framework_api_key.permissions import BaseHasAPIKey, KeyParser
+
+class BearerKeyParser(KeyParser):
+    keyword = "Bearer"
+
+
+class HasAPIKey(BaseHasAPIKey):
+    model = APIKey # or your custom model
+    key_parser = BearerKeyParser()
+```
+
+Clients must now make authorized requests using:
+
+```
+Authorization: Bearer <API_KEY>
+```
+
+where `<API_KEY>` refers to the full generated API key.
 
 ### Key generation
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -110,6 +110,27 @@ where `<API_KEY>` refers to the full generated API key.
 
 Please refer to [HttpRequest.META](https://docs.djangoproject.com/en/2.2/ref/request-response/#django.http.HttpRequest.META) for more information on headers in Django.
 
+#### Custom keyword
+
+You can set the `API_KEY_CUSTOM_KEYWORD` setting to a non-`None` value to require clients to pass their API key with a custom keyword instead of the `Api-Key` keyword.
+
+This is useful if are writing your API for an application the requires a certain keyword, like `Bearer`. 
+
+For example, if you set:
+
+```python
+# settings.py
+API_KEY_CUSTOM_KEYWORD = "Bearer"
+```
+
+then clients must make authorized requests using:
+
+```
+Authorization: Bearer <API_KEY>
+```
+
+where `<API_KEY>` refers to the full generated API key.
+
 ### Creating and managing API keys
 
 #### Admin site

--- a/src/rest_framework_api_key/permissions.py
+++ b/src/rest_framework_api_key/permissions.py
@@ -8,6 +8,8 @@ from .models import AbstractAPIKey, APIKey
 
 
 class KeyParser:
+    keyword = "Api-Key"
+
     def get(self, request: HttpRequest) -> typing.Optional[str]:
         custom_header = getattr(settings, "API_KEY_CUSTOM_HEADER", None)
 
@@ -18,13 +20,12 @@ class KeyParser:
 
     def get_from_authorization(self, request: HttpRequest) -> typing.Optional[str]:
         authorization = request.META.get("HTTP_AUTHORIZATION")
-        scheme = getattr(settings, "API_KEY_SCHEME", "Api-Key")
 
         if not authorization:
             return None
 
         try:
-            _, key = authorization.split("{} ".format(custom_keyword))
+            _, key = authorization.split("{} ".format(self.keyword))
         except ValueError:
             key = None
 

--- a/src/rest_framework_api_key/permissions.py
+++ b/src/rest_framework_api_key/permissions.py
@@ -18,13 +18,12 @@ class KeyParser:
 
     def get_from_authorization(self, request: HttpRequest) -> typing.Optional[str]:
         authorization = request.META.get("HTTP_AUTHORIZATION")
-        custom_keyword = getattr(settings, "API_KEY_CUSTOM_KEYWORD", "Api-Key")
 
         if not authorization:
             return None
 
         try:
-            _, key = authorization.split("{} ".format(custom_keyword))
+            _, key = authorization.split("Api-Key ")
         except ValueError:
             key = None
 

--- a/src/rest_framework_api_key/permissions.py
+++ b/src/rest_framework_api_key/permissions.py
@@ -18,7 +18,7 @@ class KeyParser:
 
     def get_from_authorization(self, request: HttpRequest) -> typing.Optional[str]:
         authorization = request.META.get("HTTP_AUTHORIZATION")
-        custom_keyword = getattr(settings, "API_KEY_CUSTOM_KEYWORD", "Api-Key")
+        scheme = getattr(settings, "API_KEY_SCHEME", "Api-Key")
 
         if not authorization:
             return None

--- a/src/rest_framework_api_key/permissions.py
+++ b/src/rest_framework_api_key/permissions.py
@@ -18,12 +18,13 @@ class KeyParser:
 
     def get_from_authorization(self, request: HttpRequest) -> typing.Optional[str]:
         authorization = request.META.get("HTTP_AUTHORIZATION")
+        custom_keyword = getattr(settings, "API_KEY_CUSTOM_KEYWORD", "Api-Key")
 
         if not authorization:
             return None
 
         try:
-            _, key = authorization.split("Api-Key ")
+            _, key = authorization.split("{} ".format(custom_keyword))
         except ValueError:
             key = None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,6 +90,7 @@ def fixture_key_header_config(request: typing.Any) -> typing.Iterator[dict]:
     with ctx:
         yield config
 
+
 @pytest.fixture(name="build_create_request")
 def fixture_build_create_request(key_header_config: dict) -> typing.Callable:
     from rest_framework.test import APIRequestFactory, force_authenticate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,33 +90,6 @@ def fixture_key_header_config(request: typing.Any) -> typing.Iterator[dict]:
     with ctx:
         yield config
 
-
-@pytest.fixture(
-    name="key_word_config",
-    params=[
-        {
-            "keyword": "Api-Key",
-        },
-        {
-            "keyword": "Bearer",
-            "default": "Api-Key",
-            "set_custom_keyword_setting": True,
-        },
-    ],
-)
-def fixture_key_word_config(request: typing.Any) -> typing.Iterator[dict]:
-    config: dict = request.param
-
-    ctx: typing.ContextManager[None]
-    if config.get("set_custom_keyword_setting"):
-        ctx = override_settings(API_KEY_CUSTOM_KEYWORD=config["keyword"])
-    else:
-        ctx = nullcontext()
-
-    with ctx:
-        yield config
-
-
 @pytest.fixture(name="build_create_request")
 def fixture_build_create_request(key_header_config: dict) -> typing.Callable:
     from rest_framework.test import APIRequestFactory, force_authenticate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,32 @@ def fixture_key_header_config(request: typing.Any) -> typing.Iterator[dict]:
         yield config
 
 
+@pytest.fixture(
+    name="key_word_config",
+    params=[
+        {
+            "keyword": "Api-Key",
+        },
+        {
+            "keyword": "Bearer",
+            "default": "Api-Key",
+            "set_custom_keyword_setting": True,
+        },
+    ],
+)
+def fixture_key_word_config(request: typing.Any) -> typing.Iterator[dict]:
+    config: dict = request.param
+
+    ctx: typing.ContextManager[None]
+    if config.get("set_custom_header_setting"):
+        ctx = override_settings(API_KEY_CUSTOM_KEYWORD=config["keyword"])
+    else:
+        ctx = nullcontext()
+
+    with ctx:
+        yield config
+
+
 @pytest.fixture(name="build_create_request")
 def fixture_build_create_request(key_header_config: dict) -> typing.Callable:
     from rest_framework.test import APIRequestFactory, force_authenticate

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,7 +108,7 @@ def fixture_key_word_config(request: typing.Any) -> typing.Iterator[dict]:
     config: dict = request.param
 
     ctx: typing.ContextManager[None]
-    if config.get("set_custom_header_setting"):
+    if config.get("set_custom_keyword_setting"):
         ctx = override_settings(API_KEY_CUSTOM_KEYWORD=config["keyword"])
     else:
         ctx = nullcontext()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -85,7 +85,8 @@ def test_api_key_manager_get_from_key_invalid_key():
     with pytest.raises(APIKey.DoesNotExist):
         APIKey.objects.get_from_key(invalid_key)
 
+
 def test_api_key_str():
     _, generated_key = APIKey.objects.create_key(name="test")
     retrieved_key = APIKey.objects.get_from_key(generated_key)
-    assert (str(retrieved_key) == "test")
+    assert str(retrieved_key) == "test"

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -84,3 +84,8 @@ def test_api_key_manager_get_from_key_invalid_key():
     invalid_key = f"{prefix}.foobar"
     with pytest.raises(APIKey.DoesNotExist):
         APIKey.objects.get_from_key(invalid_key)
+
+def test_api_key_str():
+    _, generated_key = APIKey.objects.create_key(name="test")
+    retrieved_key = APIKey.objects.get_from_key(generated_key)
+    assert (str(retrieved_key) == "test")

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -64,17 +64,6 @@ def test_if_invalid_api_key_then_permission_denied(
     response = view(request)
     assert response.status_code == 403
 
-# def test_if_custom_custom_api_keyword_permission_granted(
-#     create_request, view, key_header_config
-# ):
-#     keyword = "Bad-Keyword"
-#     def get_authorization(key):
-#         return key_header_config["default"].format(key=key).replace("Api-Key", keyword)
-
-#     request = create_request(authorization=get_authorization)
-#     response = view(request)
-#     assert response.status_code == 403
-
 def test_if_custom_api_keyword_permission_granted(
     create_request, view, key_header_config
 ):
@@ -86,17 +75,6 @@ def test_if_custom_api_keyword_permission_granted(
         request = create_request(authorization=get_authorization)
         response = view(request)
         assert response.status_code == 200
-
-def test_if_missing_custom_api_keyword_setting_permission_denied(
-    create_request, view, key_header_config
-):
-    keyword = "Bearer"
-    def get_authorization(key):
-        return key_header_config["default"].format(key=key).replace("Api-Key", keyword)
-
-    request = create_request(authorization=get_authorization)
-    response = view(request)
-    assert response.status_code == 403
 
 def test_if_revoked_then_permission_denied(create_request, view):
     request = create_request(revoked=True)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -64,6 +64,39 @@ def test_if_invalid_api_key_then_permission_denied(
     response = view(request)
     assert response.status_code == 403
 
+# def test_if_custom_custom_api_keyword_permission_granted(
+#     create_request, view, key_header_config
+# ):
+#     keyword = "Bad-Keyword"
+#     def get_authorization(key):
+#         return key_header_config["default"].format(key=key).replace("Api-Key", keyword)
+
+#     request = create_request(authorization=get_authorization)
+#     response = view(request)
+#     assert response.status_code == 403
+
+def test_if_custom_api_keyword_permission_granted(
+    create_request, view, key_header_config
+):
+    keyword = "Bearer"
+    def get_authorization(key):
+        return key_header_config["default"].format(key=key).replace("Api-Key", keyword)
+
+    with override_settings(API_KEY_CUSTOM_KEYWORD = keyword):
+        request = create_request(authorization=get_authorization)
+        response = view(request)
+        assert response.status_code == 200
+
+def test_if_missing_custom_api_keyword_setting_permission_denied(
+    create_request, view, key_header_config
+):
+    keyword = "Bearer"
+    def get_authorization(key):
+        return key_header_config["default"].format(key=key).replace("Api-Key", keyword)
+
+    request = create_request(authorization=get_authorization)
+    response = view(request)
+    assert response.status_code == 403
 
 def test_if_revoked_then_permission_denied(create_request, view):
     request = create_request(revoked=True)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -64,18 +64,6 @@ def test_if_invalid_api_key_then_permission_denied(
     response = view(request)
     assert response.status_code == 403
 
-def test_if_custom_api_keyword_permission_granted(
-    create_request, view, key_header_config
-):
-    keyword = "Bearer"
-    def get_authorization(key):
-        return key_header_config["default"].format(key=key).replace("Api-Key", keyword)
-
-    with override_settings(API_KEY_CUSTOM_KEYWORD = keyword):
-        request = create_request(authorization=get_authorization)
-        response = view(request)
-        assert response.status_code == 200
-
 def test_if_revoked_then_permission_denied(create_request, view):
     request = create_request(revoked=True)
     response = view(request)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -6,7 +6,8 @@ from django.test import override_settings
 from rest_framework import generics, permissions
 from rest_framework.response import Response
 
-from rest_framework_api_key.permissions import HasAPIKey
+from rest_framework_api_key.models import APIKey
+from rest_framework_api_key.permissions import BaseHasAPIKey, HasAPIKey, KeyParser
 
 from .utils import create_view_with_permissions
 
@@ -64,6 +65,7 @@ def test_if_invalid_api_key_then_permission_denied(
     response = view(request)
     assert response.status_code == 403
 
+
 def test_if_revoked_then_permission_denied(create_request, view):
     request = create_request(revoked=True)
     response = view(request)
@@ -100,3 +102,23 @@ def test_object_permission(create_request):
     request = create_request(authorization=None)
     response = view(request)
     assert response.status_code == 403
+
+
+def test_keyparser_keyword_override(create_request, key_header_config):
+    class BearerKeyParser(KeyParser):
+        keyword = "Bearer"
+
+    class BearerHasAPIKey(BaseHasAPIKey):
+        model = APIKey
+        key_parser = BearerKeyParser()
+
+    bearer_view = create_view_with_permissions(BearerHasAPIKey)
+
+    keyword = "Bearer"
+
+    def get_authorization(key):
+        return key_header_config["default"].format(key=key).replace("Api-Key", keyword)
+
+    request = create_request(authorization=get_authorization)
+    response = bearer_view(request)
+    assert response.status_code == 200


### PR DESCRIPTION
This Pull request will add the ability to specify a custom API Keyword by overriding the `KeyParser` class. 
Example:
```py
from rest_framework_api_key.permissions import BaseHasAPIKey, KeyParser

class BearerKeyParser(KeyParser):
    keyword = "Bearer"


class HasAPIKey(BaseHasAPIKey):
    key_parser = BearerKeyParser()
```

This will allow you to use Bearer

Closes: #174