### PR TITLE
fix "Should I use API keys?" documentation link Closes: #176

### DIFF
--- a/guide/index.html
+++ b/guide/index.html
@@ -908,7 +908,7 @@
 <p>If the built-in <code>APIKey</code> model doesn't fit your needs, you can create your own by subclassing <code>AbstractAPIKey</code>. This is particularly useful if you need to <strong>store extra information</strong> or <strong>link API keys to other models</strong> using a <code>ForeignKey</code> or a <code>ManyToManyField</code>.</p>
 <div class="admonition warning">
 <p class="admonition-title">Warning</p>
-<p>Associating API keys to users, directly or indirectly, can present a security risk. See also: <a href="/#should-i-use-api-keys">Should I use API keys?</a>.</p>
+<p>Associating API keys to users, directly or indirectly, can present a security risk. See also: <a href="/djangorestframework-api-key/#should-i-use-api-keys">Should I use API keys?</a>.</p>
 </div>
 <h4 id="example">Example<a class="headerlink" href="#example" title="Permanent link">&para;</a></h4>
 <p>Here's how you could link API keys to an imaginary <code>Organization</code> model:</p>


### PR DESCRIPTION
This will fix the broken "Should I use API keys?" documentation link.

Closes: #176