### PR TITLE
Format code under tests/

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -2,7 +2,7 @@
 
 . scripts/env
 
-export SOURCE_FILES="src/rest_framework_api_key test_project/ tests/conftest.py"
+export SOURCE_FILES="src/rest_framework_api_key test_project/ tests"
 
 set -x
 

--- a/scripts/check
+++ b/scripts/check
@@ -3,11 +3,11 @@
 . scripts/env
 
 export SOURCE_FILES="src/rest_framework_api_key test_project/ tests"
-
+export MYPY_SOURCE_FILES="src/rest_framework_api_key test_project tests/conftest.py"
 set -x
 
 ${PREFIX}black --check --diff --target-version=py36 $SOURCE_FILES
 ${PREFIX}flake8 $SOURCE_FILES
-${PREFIX}mypy $SOURCE_FILES
+${PREFIX}mypy $MYPY_SOURCE_FILES
 ${PREFIX}isort --check --diff $SOURCE_FILES
 ${PREFIX}python scripts/makemigrations --check

--- a/scripts/lint
+++ b/scripts/lint
@@ -2,7 +2,7 @@
 
 . scripts/env
 
-export SOURCE_FILES="src/rest_framework_api_key test_project tests/conftest.py"
+export SOURCE_FILES="src/rest_framework_api_key test_project tests"
 
 set -x
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,8 +103,7 @@ def fixture_build_create_request(key_header_config: dict) -> typing.Callable:
         _MISSING = object()
 
         def create_request(
-            authenticated: bool = False,
-            **kwargs: typing.Any,
+            authenticated: bool = False, **kwargs: typing.Any,
         ) -> HttpRequest:
             headers = {}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,8 @@ def fixture_build_create_request(key_header_config: dict) -> typing.Callable:
         _MISSING = object()
 
         def create_request(
-            authenticated: bool = False, **kwargs: typing.Any,
+            authenticated: bool = False,
+            **kwargs: typing.Any,
         ) -> HttpRequest:
             headers = {}
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -3,14 +3,13 @@ from django.contrib.admin import site
 from django.contrib.messages import get_messages
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
-from django.test import RequestFactory
 from django.http.request import HttpRequest
+from django.test import RequestFactory
+from test_project.heroes.admin import HeroAPIKeyModelAdmin
+from test_project.heroes.models import Hero, HeroAPIKey
 
 from rest_framework_api_key.admin import APIKeyModelAdmin
 from rest_framework_api_key.models import APIKey
-
-from test_project.heroes.admin import HeroAPIKeyModelAdmin
-from test_project.heroes.models import Hero, HeroAPIKey
 
 
 def build_admin_request(rf: RequestFactory) -> HttpRequest:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3,9 +3,10 @@ import string
 import pytest
 from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
+from test_project.heroes.models import Hero, HeroAPIKey
+
 from rest_framework_api_key.models import APIKey
 
-from test_project.heroes.models import HeroAPIKey, Hero
 from .dateutils import NOW, TOMORROW, YESTERDAY
 
 pytestmark = pytest.mark.django_db

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -5,8 +5,10 @@ from django.conf.global_settings import PASSWORD_HASHERS
 from django.test import override_settings
 from rest_framework import generics, permissions
 from rest_framework.response import Response
-from .utils import create_view_with_permissions
+
 from rest_framework_api_key.permissions import HasAPIKey
+
+from .utils import create_view_with_permissions
 
 pytestmark = pytest.mark.django_db
 

--- a/tests/test_permissions_combination.py
+++ b/tests/test_permissions_combination.py
@@ -2,6 +2,7 @@ import pytest
 from rest_framework.permissions import IsAuthenticated
 
 from rest_framework_api_key.permissions import HasAPIKey
+
 from .utils import create_view_with_permissions
 
 pytestmark = pytest.mark.django_db

--- a/tests/test_permissions_custom.py
+++ b/tests/test_permissions_custom.py
@@ -1,7 +1,7 @@
 import pytest
-
-from test_project.heroes.models import HeroAPIKey, Hero
+from test_project.heroes.models import Hero, HeroAPIKey
 from test_project.heroes.permissions import HasHeroAPIKey
+
 from .utils import create_view_with_permissions
 
 pytestmark = pytest.mark.django_db

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,8 +1,8 @@
 import typing
 
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.response import Response
 from rest_framework.permissions import BasePermission
+from rest_framework.response import Response
 
 
 def create_view_with_permissions(


### PR DESCRIPTION
I realized by reviewing #175 that only `tests/conftest.py` was subject to code formatting (autoflake, black, etc). I think we want _all_ of `tests/` to be code-formatted and linted.

So this PR updates `scripts/check` and `scripts/lint`, and contains the result of running `scripts/lint`.