### PR TITLE
Update CI templates to 3.4

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -4,7 +4,7 @@ resources:
       type: github
       endpoint: github
       name: florimondmanca/azure-pipelines-templates
-      ref: refs/tags/3.0
+      ref: refs/tags/3.4
   containers:
     - container: pg11
       image: postgres:11
@@ -30,13 +30,9 @@ jobs:
     parameters:
       pythonVersion: "3.8"
 
-  - job: Docs
-    steps:
-      - template: step--python-install.yml@templates
-        parameters:
-          pythonVersion: "3.8"
-      - bash: scripts/docs build
-        displayName: "Build docs"
+  - template: job--python-docs-build.yml@templates
+    parameters:
+      pythonVersion: "3.8"
 
   - template: job--python-test.yml@templates
     parameters:


### PR DESCRIPTION
* Use new standardized docs-build job
* Templates v3.4 use ubuntu-18.04 by default, preventing an issue on check and docs jobs that would run deprecated ubuntu-16.04 otherwise (refs https://github.com/florimondmanca/djangorestframework-api-key/pull/175#issuecomment-915201866):

```
##[error]This is a scheduled Ubuntu 16.04 brownout. Ubuntu 16.04 LTS environment will be removed on September 20, 2021. For more details, see https://github.com/actions/virtual-environments/issues/3287
,##[error]The remote provider was unable to process the request.
Started: mar. at 16:06
Duration: 1d 20h 54m
```