### PR TITLE
Deploy docs manually

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ scripts/serve
 Build the documentation using:
 
 ```bash
-scripts/docs
+scripts/docs build
 ```
 
 ## Notes to maintainers
@@ -76,3 +76,4 @@ scripts/docs
     - Release title, `Version 2.1.0`.
     - Description copied from the changelog.
 - Once created, this release will be automatically uploaded to PyPI via a publish job on Azure Pipelines.
+- Deploy the docs using: `scripts/docs gh-deploy`

--- a/scripts/publish
+++ b/scripts/publish
@@ -5,4 +5,3 @@
 set -x
 
 ${PREFIX}twine upload dist/*
-scripts/docs gh-deploy --force


### PR DESCRIPTION
Follow-up to #182 

Azure Pipelines is not yet configured to push to GitHub (`mkdocs gh-deploy` pushes to the `gh-pages` branch), so `scripts/docs gh-deploy` fails on CI. See: https://dev.azure.com/florimondmanca/public/_build/results?buildId=1236&view=logs&j=1d8102be-1b57-5858-ccce-e1484c113a01&t=c37d61ed-8649-56ca-791d-73e7296a747c

For now, let's hint release managers to deploy the docs manually after a release.