### PR TITLE
Fix migrations when run against a non default database.

### DIFF
--- a/src/rest_framework_api_key/migrations/0004_prefix_hashed_key.py
+++ b/src/rest_framework_api_key/migrations/0004_prefix_hashed_key.py
@@ -10,7 +10,7 @@ DEPENDENCIES = [(APP_NAME, "0003_auto_20190623_1952")]
 def populate_prefix_hashed_key(apps, schema_editor) -> None:  # type: ignore
     model = apps.get_model(APP_NAME, MODEL_NAME)
 
-    for api_key in model.objects.all():
+    for api_key in model.objects.using(schema_editor.connection.alias).all():
         prefix, _, hashed_key = api_key.id.partition(".")
         api_key.prefix = prefix
         api_key.hashed_key = hashed_key

--- a/test_project/heroes/migrations/0002_prefix_hashed_key.py
+++ b/test_project/heroes/migrations/0002_prefix_hashed_key.py
@@ -10,7 +10,7 @@ DEPENDENCIES = [(APP_NAME, "0001_initial")]
 def populate_prefix_hashed_key(apps, schema_editor):  # type: ignore
     model = apps.get_model(APP_NAME, MODEL_NAME)
 
-    for api_key in model.objects.all():
+    for api_key in model.objects.using(schema_editor.connection.alias).all():
         prefix, _, hashed_key = api_key.id.partition(".")
         api_key.prefix = prefix
         api_key.hashed_key = hashed_key

--- a/test_project/project/settings.py
+++ b/test_project/project/settings.py
@@ -55,7 +55,10 @@ WSGI_APPLICATION = "project.wsgi.application"
 
 # Database
 
-DATABASES = {"default": dj_database_url.config(default="sqlite://db.sqlite3")}
+DATABASES = {
+    "default": dj_database_url.config(default="sqlite://:memory:"),
+    "test": dj_database_url.config(default="sqlite://:memory:"),
+}
 
 
 # Password validation

--- a/test_project/project/settings.py
+++ b/test_project/project/settings.py
@@ -56,8 +56,8 @@ WSGI_APPLICATION = "project.wsgi.application"
 # Database
 
 DATABASES = {
-    "default": dj_database_url.config(default="sqlite://:memory:"),
-    "test": dj_database_url.config(default="sqlite://:memory:"),
+    "default": dj_database_url.config(default="sqlite:///db.sqlite3"),
+    "test": dj_database_url.config("TEST_DATABASE_URL", default="sqlite://test.sqlite3"),
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,8 @@ def pytest_configure() -> None:
             ],
             "ROOT_URLCONF": "test_project.project.urls",
             "DATABASES": {
-                "default": dj_database_url.config(default="sqlite://:memory:")
+                "default": dj_database_url.config(default="sqlite://:memory:"),
+                "test": dj_database_url.config(default="sqlite://:memory:"),
             },
         }
     )


### PR DESCRIPTION
We are using this library on a project that is running tests with a separate test database. Previously due to the missing
`using` statement it would instead try to apply the `populate_prefix_hashed_key` using the default database connection.