### PR TITLE
Bump deps, add official Django 3.2 and Py3.9/3.10 support

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -71,3 +71,4 @@ stages:
       - template: job--python-publish.yml@templates
         parameters:
           token: $(pypiToken)
+          pythonVersion: "3.10"

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -4,7 +4,7 @@ resources:
       type: github
       endpoint: github
       name: florimondmanca/azure-pipelines-templates
-      ref: refs/tags/3.4
+      ref: refs/tags/4.0
   containers:
     - container: pg11
       image: postgres:11
@@ -34,11 +34,11 @@ stages:
     jobs:
       - template: job--python-check.yml@templates
         parameters:
-          pythonVersion: "3.8"
+          pythonVersion: "3.10"
 
       - template: job--python-docs-build.yml@templates
         parameters:
-          pythonVersion: "3.8"
+          pythonVersion: "3.10"
 
       - template: job--python-test.yml@templates
         parameters:
@@ -47,14 +47,14 @@ stages:
               variables:
                 DJANGO_VERSION: "2.2.*"
 
-            py37_dj30:
+            py37_dj32:
               variables:
-                DJANGO_VERSION: "3.0.*"
+                DJANGO_VERSION: "3.2.*"
 
-            py38_dj30:
+            py310_dj32:
               coverage: true
               variables:
-                DJANGO_VERSION: "3.0.*"
+                DJANGO_VERSION: "3.2.*"
 
             py38_windows:
               os: windows

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 -e .
 
 # Django environment.
-django[argon2,bcrypt]==3.0.*
-djangorestframework==3.10.*
+django[argon2,bcrypt]==3.2.*
+djangorestframework==3.12.*
 dj-database-url
 django-dotenv
 
@@ -15,16 +15,16 @@ wheel
 
 # Tooling.
 autoflake
-black==20.8b1
+black==21.11b1
 flake8
 flake8-bugbear
 flake8-comprehensions
 isort==5.*
 mkdocs==1.*
-mkdocs-material==4.*
-pymdown-extensions==6.*
+mkdocs-material==8.*
+pymdown-extensions==9.*
 mypy
-pytest==5.*
-pytest-django==3.5.*
+pytest==6.*
+pytest-django==4.*
 pytest-cov
 seed-isort-config

--- a/setup.py
+++ b/setup.py
@@ -44,10 +44,12 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Environment :: Web Environment",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Framework :: Django",
         "Framework :: Django :: 2.2",
-        "Framework :: Django :: 3.0",
+        "Framework :: Django :: 3.2",
     ],
 )

--- a/test_project/heroes/apps.py
+++ b/test_project/heroes/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class HeroesConfig(AppConfig):
-    name = "heroes"
+    name = "test_project.heroes"


### PR DESCRIPTION
Quick overhaul of deps and package versions:

- Test under Django 2.2 and 3.2 only, as 3.0 is deprecated and 3.1 will soon be (see [Django - Supported versions](https://www.djangoproject.com/download/#supported-versions))
- Update CI templates and test under Python 3.10 (update trove classifiers, adding Python 3.9 and 3.10)
- Update dev dependencies