### PR TITLE
Explore swappable API key model functionality

### DIFF
--- a/src/rest_framework_api_key/admin.py
+++ b/src/rest_framework_api_key/admin.py
@@ -4,7 +4,7 @@ from django.contrib import admin, messages
 from django.db import models
 from django.http.request import HttpRequest
 
-from .models import AbstractAPIKey, APIKey
+from .models import AbstractAPIKey
 
 
 class APIKeyModelAdmin(admin.ModelAdmin):
@@ -54,7 +54,5 @@ class APIKeyModelAdmin(admin.ModelAdmin):
         else:
             obj.save()
 
-
-admin.site.register(APIKey, APIKeyModelAdmin)
 
 APIKeyAdmin = APIKeyModelAdmin  # Compatibility with <1.3

--- a/src/rest_framework_api_key/models.py
+++ b/src/rest_framework_api_key/models.py
@@ -1,6 +1,8 @@
 import typing
 
-from django.core.exceptions import ValidationError
+from django.apps import apps as django_apps
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models
 from django.utils import timezone
 
@@ -142,5 +144,31 @@ class AbstractAPIKey(models.Model):
         return str(self.name)
 
 
+def get_swappable_setting() -> str:
+    if not hasattr(settings, "API_KEY_MODEL"):
+        # Ensure a default value is set.
+        settings.API_KEY_MODEL = "rest_framework_api_key.APIKey"
+
+    return "API_KEY_MODEL"
+
+
 class APIKey(AbstractAPIKey):
-    pass
+    class Meta(AbstractAPIKey.Meta):
+        swappable = get_swappable_setting()
+
+
+def get_api_key_model() -> typing.Type[AbstractAPIKey]:
+    """
+    Return the API key model that is active in this project.
+    """
+    try:
+        return django_apps.get_model(settings.API_KEY_MODEL, require_ready=False)
+    except ValueError:
+        raise ImproperlyConfigured(
+            "API_KEY_MODEL must be of the form 'app_label.model_name'"
+        )
+    except LookupError:
+        raise ImproperlyConfigured(
+            "API_KEY_MODEL refers to model '%s' that has not been installed"
+            % settings.API_KEY_MODEL
+        )

--- a/src/rest_framework_api_key/permissions.py
+++ b/src/rest_framework_api_key/permissions.py
@@ -4,7 +4,7 @@ from django.conf import settings
 from django.http import HttpRequest
 from rest_framework import permissions
 
-from .models import AbstractAPIKey, APIKey
+from .models import AbstractAPIKey, get_api_key_model
 
 
 class KeyParser:
@@ -59,4 +59,4 @@ class BaseHasAPIKey(permissions.BasePermission):
 
 
 class HasAPIKey(BaseHasAPIKey):
-    model = APIKey
+    model = get_api_key_model()

--- a/test_project/project/settings.py
+++ b/test_project/project/settings.py
@@ -82,3 +82,8 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 
 STATIC_URL = "/static/"
+
+
+# API keys
+
+API_KEY_MODEL = "heroes.HeroAPIKey"


### PR DESCRIPTION
This is an illustration of a possible resolution for #180.

* Allows users to define a default API key model they'd like to use.
* If "a default API key model" does not make sense for their use case (e.g. maybe they have multiple custom API key models), then the default `APIKey` model would still get created. I'm not sure there's a sensible way out of this, because allowing dropping the model midways, e.g. via `API_KEY_MODEL = None`, would add migration questions for existing apps.
* However, this PR also proposes to not `register()` any API key models by default, meaning at least they wouldn't see it in the admin. It's possible we want this to be a separate, isolated PR.