### PR TITLE
Add support for parse API-Key as base64_encoded string

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -347,6 +347,21 @@ class HasAPIKey(BaseHasAPIKey):
     key_parser = CookieKeyParser()
 ```
 
+By default, clients pass their API key as a plaintext, You can set the `API_KEY_BASE64_ENCODED` setting to `True` value
+, to accept the API key as Base64 Encoded string instead of plaintext.
+
+```python
+# settings.py
+API_KEY_BASE64_ENCODED = True
+```
+
+```python
+# Example of converting the key value to b64encoded value
+import base64
+key = "<API_KEY>"
+key_b64encoded = base64.b64encode(key.encode("UTF-8")).decode("UTF-8")
+```
+
 ### Key generation
 
 !!! warning

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ wheel
 
 # Tooling.
 autoflake
-black==21.11b1
+black==22.3.0
 flake8
 flake8-bugbear
 flake8-comprehensions

--- a/src/rest_framework_api_key/permissions.py
+++ b/src/rest_framework_api_key/permissions.py
@@ -21,10 +21,13 @@ class KeyParser:
             api_key = self.get_from_authorization(request)
 
         base64_encoded = getattr(settings, "API_KEY_BASE64_ENCODED", False)
-        if base64_encoded:
+        if base64_encoded and api_key:
             try:
                 api_key = base64.b64decode(api_key, validate=True).decode("UTF-8")
-            except (binascii.Error, UnicodeDecodeError):  # API-Key not correctly base64 encoded.
+            except (
+                binascii.Error,
+                UnicodeDecodeError,
+            ):  # API-Key not correctly base64 encoded.
                 api_key = None
         return api_key
 


### PR DESCRIPTION
# Add support for parse API-Key as base64_encoded string

- Adding support for parse API-Key as base64_encoded string in KeyParser
- Adding illustration at docs/guide.md
- Adding test-case covers the changes


----
By default, clients pass their API key as a plaintext, You can set the `API_KEY_BASE64_ENCODED` setting to `True` value
, to accept the API key as Base64 Encoded string instead of plaintext.
```python
# settings.py
API_KEY_BASE64_ENCODED = True
```
```python
# Example of converting the key value to b64encoded value
import base64
key = "<API_KEY>"
key_b64encoded = base64.b64encode(key.encode("UTF-8")).decode("UTF-8")
```