### PR TITLE
Bump dev dependencies, fix CI installing django from $DJANGO_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ install:
 	python3 -m venv ${venv}
 	${bin}pip install -U pip wheel
 	${bin}pip install -r requirements.txt
+	./tools/install_django.sh ${bin}pip
 
 format:
 	${bin}autoflake --in-place --recursive ${pysources}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -e .
 
 # Django environment.
-django[argon2,bcrypt]==4.0.5
+# django[argon2,bcrypt]  # See tools/install_django.sh
 djangorestframework==3.13.1
 dj-database-url
 django-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 -e .
 
 # Django environment.
-django[argon2,bcrypt]==3.2.*
-djangorestframework==3.12.*
+django[argon2,bcrypt]==4.0.5
+djangorestframework==3.13.1
 dj-database-url
 django-dotenv
 
@@ -20,11 +20,11 @@ flake8
 flake8-bugbear
 flake8-comprehensions
 isort==5.*
-mkdocs==1.*
-mkdocs-material==8.*
-pymdown-extensions==9.*
+mkdocs==1.3.0
+mkdocs-material==8.3.1
+pymdown-extensions==9.4
 mypy
-pytest==6.*
-pytest-django==4.*
+pytest==7.1.2
+pytest-django==4.5.2
 pytest-cov
 seed-isort-config

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -4,6 +4,7 @@ from django.contrib.messages import get_messages
 from django.contrib.messages.middleware import MessageMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.http.request import HttpRequest
+from django.http.response import HttpResponse
 from django.test import RequestFactory
 from test_project.heroes.admin import HeroAPIKeyModelAdmin
 from test_project.heroes.models import Hero, HeroAPIKey
@@ -15,10 +16,13 @@ from rest_framework_api_key.models import APIKey
 def build_admin_request(rf: RequestFactory) -> HttpRequest:
     request = rf.post("/")
 
+    def get_response(request: HttpRequest) -> HttpResponse:
+        raise NotImplementedError  # Unused in these tests.
+
     # NOTE: all middleware must be instantiated before
     # any middleware can process the request.
-    sessions = SessionMiddleware()
-    messages = MessageMiddleware()
+    sessions = SessionMiddleware(get_response)
+    messages = MessageMiddleware(sessions.get_response)
 
     sessions.process_request(request)
     messages.process_request(request)

--- a/tools/install_django.sh
+++ b/tools/install_django.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -ex
+
+PIP="$1"
+
+DJANGO_VERSION=${DJANGO_VERSION:-4.0.5}
+
+exec ${PIP} install django[argon2,bcrypt]==$DJANGO_VERSION


### PR DESCRIPTION
Bump dev dependencies, and test against Django 4.0 as a first step towards #205.

Also fixes CI that stopped installing using `$DJANGO_VERSION` as #198 forgot to port this part over: https://github.com/florimondmanca/djangorestframework-api-key/pull/198/files#diff-6233345de4867c7ccf72bac1fc1067988d2a4c8e1ab9a746956eafccf88cfed2L15-L17