### PR TITLE
Reach 100% test coverage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ black==22.3.0
 flake8
 flake8-bugbear
 flake8-comprehensions
+django-test-migrations==1.2.0
 isort==5.*
 mkdocs==1.3.0
 mkdocs-material==8.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,4 +17,4 @@ addopts =
   --cov=rest_framework_api_key
   --cov=tests
   --cov-report=term-missing
-  --cov-fail-under=80
+  --cov-fail-under=100

--- a/src/rest_framework_api_key/__init__.py
+++ b/src/rest_framework_api_key/__init__.py
@@ -2,7 +2,7 @@ import django
 
 from .__version__ import __version__
 
-if django.VERSION < (3, 2):
+if django.VERSION < (3, 2):  # pragma: no cover
     default_app_config = "rest_framework_api_key.apps.RestFrameworkApiKeyConfig"
 
 __all__ = ["__version__", "default_app_config"]

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -7,12 +7,12 @@ import rest_framework_api_key
 @pytest.mark.skipif(
     django.VERSION < (3, 2), reason="app config is automatically defined by django"
 )
-def test_app_config_not_defined() -> None:
+def test_app_config_not_defined() -> None:  # pragma: no cover
     assert hasattr(rest_framework_api_key, "default_app_config") is False
 
 
 @pytest.mark.skipif(
     django.VERSION >= (3, 2), reason="app config is not automatically defined by django"
 )
-def test_app_config_defined() -> None:
+def test_app_config_defined() -> None:  # pragma: no cover
     assert hasattr(rest_framework_api_key, "default_app_config") is True

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,65 @@
+from typing import Any, Tuple
+
+import pytest
+from django_test_migrations.migrator import Migrator
+
+
+@pytest.mark.django_db
+def test_migrations_0001_initial(migrator: Migrator) -> None:
+    old_state = migrator.apply_initial_migration(("rest_framework_api_key", None))
+
+    with pytest.raises(LookupError):
+        old_state.apps.get_model("rest_framework_api_key", "APIKey")
+
+    new_state = migrator.apply_tested_migration(
+        ("rest_framework_api_key", "0001_initial")
+    )
+    APIKey = new_state.apps.get_model("rest_framework_api_key", "APIKey")
+    assert APIKey.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_migrations_0004_prefix_hashed_key(migrator: Migrator) -> None:
+    from django.contrib.auth.hashers import make_password
+    from django.utils.crypto import get_random_string
+
+    def _generate() -> Tuple[str, str]:
+        # Replicate bejavior before PR #62 (i.e. before v1.4).
+        prefix = get_random_string(8)
+        secret_key = get_random_string(32)
+        key = prefix + "." + secret_key
+        key_id = prefix + "." + make_password(key)
+        return key, key_id
+
+    def _assign_key(obj: Any) -> None:
+        # Replicate bejavior before PR #62 (i.e. before v1.4).
+        _, hashed_key = _generate()
+        pk = hashed_key
+        prefix, _, hashed_key = hashed_key.partition(".")
+
+        obj.id = pk
+        obj.prefix = prefix
+        obj.hashed_key = hashed_key
+
+    old_state = migrator.apply_initial_migration(
+        ("rest_framework_api_key", "0003_auto_20190623_1952")
+    )
+
+    APIKey = old_state.apps.get_model("rest_framework_api_key", "APIKey")
+
+    # Create a key as it if were created before PR #62 (i.e. before v1.4).
+    api_key = APIKey.objects.create(name="test")
+    _assign_key(api_key)
+    api_key.save()
+    prefix, _, hashed_key = api_key.id.partition(".")
+
+    # Apply migration added by PR #62.
+    new_state = migrator.apply_tested_migration(
+        ("rest_framework_api_key", "0004_prefix_hashed_key")
+    )
+    APIKey = new_state.apps.get_model("rest_framework_api_key", "APIKey")
+
+    # Ensure new `prefix`` and `hashed_key` fields were successfully populated.
+    api_key = APIKey.objects.get(id=api_key.id)
+    assert api_key.prefix == prefix
+    assert api_key.hashed_key == hashed_key

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -89,6 +89,23 @@ def test_if_invalid_api_key_then_permission_denied(
     assert response.status_code == 403
 
 
+@pytest.mark.parametrize(
+    "authorization_fmt",
+    [
+        pytest.param("X-Key {key}", id="wrong-scheme"),
+        pytest.param("Api-Key:{key}", id="not-space-separated"),
+    ],
+)
+def test_if_malformed_authorization_then_permission_denied(
+    rf: RequestFactory, authorization_fmt: str
+) -> None:
+    _, key = APIKey.objects.create_key(name="test")
+    authorization = authorization_fmt.format(key=key)
+    request = rf.get("/test/", HTTP_AUTHORIZATION=authorization)
+    response = view(request)
+    assert response.status_code == 403
+
+
 def test_if_invalid_api_key_custom_header_then_permission_denied(
     rf: RequestFactory,
 ) -> None:
@@ -134,7 +151,7 @@ def test_object_permission(rf: RequestFactory) -> None:
 
         def get(self, request: Request) -> Response:
             self.check_object_permissions(request, object())
-            return Response()
+            return Response()  # pragma: no cover  # Never reached.
 
     view = View.as_view()
 


### PR DESCRIPTION
Closes #96 

* Applies relevant `pragma: no cover` invocations
* Add missing admin and permission tests.
* Test migrations using the _fantastic_ [django-test-migrations](https://github.com/wemake-services/django-test-migrations) package. (This was created in Nov 2019. Not available at the time of version 1.4, which contained #62 that added the 0004 migration. Would have been _so_ helpful to ensure migrations work in various use cases!)