### PR TITLE
Add routes to test_project

### DIFF
--- a/test_project/project/urls.py
+++ b/test_project/project/urls.py
@@ -1,4 +1,11 @@
 from django.contrib import admin
 from django.urls import path
 
-urlpatterns = [path("admin/", admin.site.urls)]
+from . import views
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("api/public/", views.PublicAPIView.as_view()),
+    path("api/protected/", views.ProtectedAPIView.as_view()),
+    path("api/protected/object/", views.ProtectedObjectAPIView.as_view()),
+]

--- a/test_project/project/views.py
+++ b/test_project/project/views.py
@@ -1,0 +1,25 @@
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from test_project.heroes.permissions import HasHeroAPIKey
+
+
+class PublicAPIView(APIView):
+    def get(self, request: Request) -> Response:
+        return Response({"message": "Hello, world!"})
+
+
+class ProtectedAPIView(APIView):
+    permission_classes = [HasHeroAPIKey]
+
+    def get(self, request: Request) -> Response:
+        return Response({"message": "Hello, world!"})
+
+
+class ProtectedObjectAPIView(APIView):
+    permission_classes = [HasHeroAPIKey]
+
+    def get(self, request: Request) -> Response:
+        self.check_object_permissions(request, object())
+        return Response({"message": "Hello, world!"})

--- a/test_project/project/views.py
+++ b/test_project/project/views.py
@@ -1,7 +1,6 @@
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
-
 from test_project.heroes.permissions import HasHeroAPIKey
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,8 +39,8 @@ def pytest_configure() -> None:
             ],
             "MIDDLEWARE": [
                 # Admin
-                "django.contrib.messages.middleware.MessageMiddleware",
                 "django.contrib.sessions.middleware.SessionMiddleware",
+                "django.contrib.messages.middleware.MessageMiddleware",
                 "django.contrib.auth.middleware.AuthenticationMiddleware",
             ],
             "ROOT_URLCONF": "test_project.project.urls",

--- a/tests/test_test_project.py
+++ b/tests/test_test_project.py
@@ -1,0 +1,22 @@
+import pytest
+from rest_framework.test import APIClient
+from test_project.heroes.models import Hero
+from test_project.heroes.permissions import HeroAPIKey
+
+
+@pytest.mark.django_db
+def test_test_project_routes() -> None:
+    batman = Hero.objects.create(name="Batman")
+    _, key = HeroAPIKey.objects.create_key(name="test", hero=batman)
+    headers = {"HTTP_AUTHORIZATION": f"Api-Key {key}"}
+
+    client = APIClient()
+
+    response = client.get("/api/public/", format="json")
+    assert response.status_code == 200
+
+    response = client.get("/api/protected/", format="json", **headers)
+    assert response.status_code == 200
+
+    response = client.get("/api/protected/object/", format="json", **headers)
+    assert response.status_code == 200


### PR DESCRIPTION
This PR adds a few example routes to the `test_project`.

As per https://github.com/florimondmanca/djangorestframework-api-key/issues/173#issuecomment-1146677315, it turns out having some example routes in the `test_project` to run requests against is quite handy for debugging, investigation, etc.

(This might need tests to preserve 100% coverage...)