### PR TITLE
Add support for upgrading API key hashes

### DIFF
--- a/src/rest_framework_api_key/crypto.py
+++ b/src/rest_framework_api_key/crypto.py
@@ -34,5 +34,15 @@ class KeyGenerator:
         hashed_key = self.hash(key)
         return key, prefix, hashed_key
 
-    def verify(self, key: str, hashed_key: str) -> bool:
-        return check_password(key, hashed_key)
+    def verify(
+        self,
+        key: str,
+        hashed_key: str,
+        hashed_key_setter: typing.Callable[[str], None] = None,
+    ) -> bool:
+        def setter(__key: str) -> None:
+            if hashed_key_setter is not None:
+                new_hashed_key = self.hash(__key)
+                hashed_key_setter(new_hashed_key)
+
+        return check_password(key, hashed_key, setter=setter)

--- a/src/rest_framework_api_key/models.py
+++ b/src/rest_framework_api_key/models.py
@@ -123,7 +123,13 @@ class AbstractAPIKey(models.Model):
     has_expired = property(_has_expired)
 
     def is_valid(self, key: str) -> bool:
-        return type(self).objects.key_generator.verify(key, self.hashed_key)
+        return type(self).objects.key_generator.verify(
+            key, self.hashed_key, hashed_key_setter=self._update_hash
+        )
+
+    def _update_hash(self, hashed_key: str) -> None:
+        self.hashed_key = hashed_key
+        self.save()
 
     def clean(self) -> None:
         self._validate_revoked()


### PR DESCRIPTION
Found out while working on https://github.com/florimondmanca/djangorestframework-api-key/issues/173#issuecomment-1146677315

Currently, if `PASSWORD_HASHERS` changes and hasher A (eg. PBKDF2) previously used to hash API keys is moved lower in the list than another hasher B (eg. Argon2), then API key hashes won't be [upgraded](https://docs.djangoproject.com/en/4.0/topics/auth/passwords/#password-upgrading).

This PR adds support for this, by implementing `verify(..., setter=...)`.

---

Needs some tests...