### PR TITLE
Drop redundant .has_object_permission impl on DRF 3.14.0 or above

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Drop redundant `.has_object_permission()` implementation on `BaseHasAPIKey` when using DRF 3.14.0 or above. (Pull #239)
+- Drop redundant `.has_object_permission()` implementation on `BaseHasAPIKey` when using DRF 3.14.0 or above. (Pull #240)
 
 ## 2.3.0 - 2023-01-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Drop redundant `.has_object_permission()` implementation on `BaseHasAPIKey` when using DRF 3.14.0 or above. (Pull #239)
+
 ## 2.3.0 - 2023-01-19
 
 ### Removed

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,
-    install_requires=[],
+    install_requires=["packaging"],
     python_requires=">=3.7",
     license="MIT",
     classifiers=[

--- a/src/rest_framework_api_key/permissions.py
+++ b/src/rest_framework_api_key/permissions.py
@@ -74,7 +74,7 @@ class BaseHasAPIKey(permissions.BasePermission):
             # not updated their DRF yet.
             return self.has_permission(request, view)
 
-        return True
+        return super().has_object_permission(request, view, obj)
 
 
 class HasAPIKey(BaseHasAPIKey):

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,10 +1,9 @@
 import datetime as dt
-from typing import Any, Callable
+from typing import Callable
 
 import pytest
 from django.conf.global_settings import PASSWORD_HASHERS
 from django.test import RequestFactory, override_settings
-from rest_framework import generics, permissions
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -139,26 +138,6 @@ def test_expiry_date(rf: RequestFactory, expiry_date: dt.datetime, ok: bool) -> 
     response = view(request)
     status_code = 200 if ok else 403
     assert response.status_code == status_code
-
-
-def test_object_permission(rf: RequestFactory) -> None:
-    class DenyObject(permissions.BasePermission):
-        def has_object_permission(self, *args: Any) -> bool:
-            return False
-
-    class View(generics.GenericAPIView):
-        permission_classes = [HasAPIKey | DenyObject]
-
-        def get(self, request: Request) -> Response:
-            self.check_object_permissions(request, object())
-            return Response()  # pragma: no cover  # Never reached.
-
-    view = View.as_view()
-
-    request = rf.get("/test/")
-
-    response = view(request)
-    assert response.status_code == 403
 
 
 def test_keyparser_keyword_override(rf: RequestFactory) -> None:


### PR DESCRIPTION
Closes #150 

This essentially reverts #25 when DRF 3.14.0 or above is detected.

Not reverting in all cases prevents breakage (i.e. API keys not being checked anymore if using them with a bitwise OR) if people upgrade DRF-api-key while still using an older DRF.