### PR TITLE
Fix typos in security docs

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -33,7 +33,7 @@ Access is granted if and only if all of the following is true:
 
 Besides, it is NOT recommended to use this package for authentication, i.e. retrieving user information from API keys.
 
-Indeed, **using API keys shifts the responsability of Information Security on your clients**. This induces risks, especially if detaining an API key gives access to confidential information or write operations. For example, an attacker could impersonate clients if they let their API keys leak.
+Indeed, **using API keys shifts the responsibility of Information Security on your clients**. This induces risks, especially if obtaining an API key gives access to confidential information or write operations. For example, an attacker could impersonate clients if they let their API keys leak.
 
 As a best practice, you should apply the _Principle of Least Privilege_: allow only those who require resources to access those specific resources. In other words: **if your client needs to access an endpoint, add API permissions on that endpoint only** instead of the whole API.
 


### PR DESCRIPTION
> detaining -> obtaining

I think that is what was meant.

> responsability -> responsibility