### PR TITLE
Version 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Use faster SHA512-based key hasher instead of password hashers. Reduces server load by making API key validation orders of magnitude faster (10x to 30x according to estimations, network latency aside). (Pull #244)
+- Use faster SHA512-based key hasher instead of password hashers. Reduces server load by making API key validation orders of magnitude faster (10x to 30x according to estimations, network latency aside). Hashed key will be transparently upgraded the first time `.is_valid()` is called. (Pull #244, Pull #251)
 - Drop redundant `.has_object_permission()` implementation on `BaseHasAPIKey` when using DRF 3.14.0 or above. (Pull #240)
 
 ## 2.3.0 - 2023-01-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 2.4.0 - 2023-09-14
+
+### Removed
+
+- Dropped support for Python 3.7, which has reached EOL. (Pull #247)
+
+### Added
+
+- Add official support for Python 3.11. (Pull #247)
 
 ### Fixed
 
+- Use faster SHA512-based key hasher instead of password hashers. Reduces server load by making API key validation orders of magnitude faster (10x to 30x according to estimations, network latency aside). (Pull #244)
 - Drop redundant `.has_object_permission()` implementation on `BaseHasAPIKey` when using DRF 3.14.0 or above. (Pull #240)
 
 ## 2.3.0 - 2023-01-19

--- a/src/rest_framework_api_key/__init__.py
+++ b/src/rest_framework_api_key/__init__.py
@@ -6,6 +6,6 @@ else:
     if django.VERSION < (3, 2):  # pragma: no cover
         default_app_config = "rest_framework_api_key.apps.RestFrameworkApiKeyConfig"
 
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 
 __all__ = ["__version__", "default_app_config"]


### PR DESCRIPTION
## 2.4.0 - 2023-09-18

### Removed

- Dropped support for Python 3.7, which has reached EOL. (Pull #247)

### Added

- Add official support for Python 3.11. (Pull #247)

### Fixed

- Use faster SHA512-based key hasher instead of password hashers. Reduces server load by making API key validation orders of magnitude faster (10x to 30x according to estimations, network latency aside). Hashed key will be transparently upgraded the first time `.is_valid()` is called. (Pull #244, Pull #251)
- Drop redundant `.has_object_permission()` implementation on `BaseHasAPIKey` when using DRF 3.14.0 or above. (Pull #240)
