### PR TITLE
add missing i18n lookups

### DIFF
--- a/src/rest_framework_api_key/apps.py
+++ b/src/rest_framework_api_key/apps.py
@@ -1,6 +1,7 @@
 from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
 
 
 class RestFrameworkApiKeyConfig(AppConfig):
     name = "rest_framework_api_key"
-    verbose_name = "API Key Permissions"
+    verbose_name = _("API Key Permissions")

--- a/src/rest_framework_api_key/models.py
+++ b/src/rest_framework_api_key/models.py
@@ -110,8 +110,8 @@ class AbstractAPIKey(models.Model):
     class Meta:  # noqa
         abstract = True
         ordering = ("-created",)
-        verbose_name = "API key"
-        verbose_name_plural = "API keys"
+        verbose_name = _("API key")
+        verbose_name_plural = _("API keys")
 
     def __init__(self, *args: typing.Any, **kwargs: typing.Any):
         super().__init__(*args, **kwargs)
@@ -123,7 +123,7 @@ class AbstractAPIKey(models.Model):
             return False
         return self.expiry_date < timezone.now()
 
-    _has_expired.short_description = "Has expired"  # type: ignore
+    _has_expired.short_description = _("Has expired")  # type: ignore
     _has_expired.boolean = True  # type: ignore
     has_expired = property(_has_expired)
 

--- a/src/rest_framework_api_key/models.py
+++ b/src/rest_framework_api_key/models.py
@@ -75,9 +75,9 @@ class AbstractAPIKey(models.Model):
     objects = APIKeyManager()
 
     id = models.CharField(max_length=150, unique=True, primary_key=True, editable=False)
-    prefix = models.CharField(max_length=8, unique=True, editable=False)
+    prefix = models.CharField(max_length=8, unique=True, editable=False, verbose_name=_("Prefix"))
     hashed_key = models.CharField(max_length=150, editable=False)
-    created = models.DateTimeField(auto_now_add=True, db_index=True)
+    created = models.DateTimeField(auto_now_add=True, db_index=True, verbose_name=_("Created"))
     name = models.CharField(
         max_length=50,
         blank=False,
@@ -93,6 +93,7 @@ class AbstractAPIKey(models.Model):
     revoked = models.BooleanField(
         blank=True,
         default=False,
+        verbose_name=_("Revoked"),
         help_text=(
             _(
                 "If the API key is revoked, clients cannot use it anymore. "


### PR DESCRIPTION
When working on an international project, I noticed that some calls to `gettext_lazy` are missing. This PR aims to fix that issue.

Perhaps this would also be the place to discuss whether it makes sense to offer translations in the repo. But I understand if the effort would be too great.