### PR TITLE
Version 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.1.0 - 2025-04-04
+
+### Added
+
+- Add official support for Python 3.12 and 3.13, and Django 5.0 up to 5.2, accomodating changes to `USE_TZ`. (Pull #266)
+
 ## 3.0.0 - 2023-09-30
 
 ### Changed

--- a/src/rest_framework_api_key/__init__.py
+++ b/src/rest_framework_api_key/__init__.py
@@ -6,6 +6,6 @@ else:
     if django.VERSION < (3, 2):  # pragma: no cover
         default_app_config = "rest_framework_api_key.apps.RestFrameworkApiKeyConfig"
 
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 
 __all__ = ["__version__", "default_app_config"]


### PR DESCRIPTION
## 3.1.0 - 2025-04-04

### Added

- Add official support for Python 3.12 and 3.13, and Django 5.0 up to 5.2, accomodating changes to `USE_TZ`. (Pull #266)
